### PR TITLE
Roll up uncompressed chunks into compressed ones

### DIFF
--- a/sql/pre_install/tables.sql
+++ b/sql/pre_install/tables.sql
@@ -112,6 +112,9 @@ CREATE TABLE _timescaledb_catalog.dimension (
   partitioning_func name NULL,
   -- open dimensions (e.g., time)
   interval_length bigint NULL,
+  -- compress interval is used by rollup procedure during compression
+  -- in order to merge multiple chunks into a single one
+  compress_interval_length bigint NULL,
   integer_now_func_schema name NULL,
   integer_now_func name NULL,
   -- table constraints
@@ -121,6 +124,7 @@ CREATE TABLE _timescaledb_catalog.dimension (
   CONSTRAINT dimension_check1 CHECK ((num_slices IS NULL AND interval_length IS NOT NULL) OR (num_slices IS NOT NULL AND interval_length IS NULL)),
   CONSTRAINT dimension_check2 CHECK ((integer_now_func_schema IS NULL AND integer_now_func IS NULL) OR (integer_now_func_schema IS NOT NULL AND integer_now_func IS NOT NULL)),
   CONSTRAINT dimension_interval_length_check CHECK (interval_length IS NULL OR interval_length > 0),
+  CONSTRAINT dimension_compress_interval_length_check CHECK (compress_interval_length IS NULL OR compress_interval_length > 0),
   CONSTRAINT dimension_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
 );
 

--- a/sql/updates/latest-dev.sql
+++ b/sql/updates/latest-dev.sql
@@ -175,3 +175,84 @@ $BODY$
          UNION ALL
          SELECT * FROM _chunk_sizes) AS sizes;
 $BODY$ SET search_path TO pg_catalog, pg_temp;
+
+-- Recreate _timescaledb_catalog.dimension table with the compress_interval_length column --
+CREATE TABLE _timescaledb_internal.dimension_tmp
+AS SELECT * from _timescaledb_catalog.dimension;
+
+CREATE TABLE _timescaledb_internal.tmp_dimension_seq_value AS
+SELECT last_value, is_called FROM _timescaledb_catalog.dimension_id_seq;
+
+--drop foreign keys on dimension table
+ALTER TABLE _timescaledb_catalog.dimension_partition DROP CONSTRAINT 
+dimension_partition_dimension_id_fkey;
+ALTER TABLE _timescaledb_catalog.dimension_slice DROP CONSTRAINT 
+dimension_slice_dimension_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS timescaledb_information.dimensions;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.dimension;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.dimension_id_seq;
+DROP TABLE _timescaledb_catalog.dimension;
+
+CREATE TABLE _timescaledb_catalog.dimension (
+  id serial NOT NULL ,
+  hypertable_id integer NOT NULL,
+  column_name name NOT NULL,
+  column_type REGTYPE NOT NULL,
+  aligned boolean NOT NULL,
+  -- closed dimensions
+  num_slices smallint NULL,
+  partitioning_func_schema name NULL,
+  partitioning_func name NULL,
+  -- open dimensions (e.g., time)
+  interval_length bigint NULL,
+  compress_interval_length bigint NULL,
+  integer_now_func_schema name NULL,
+  integer_now_func name NULL,
+  -- table constraints
+  CONSTRAINT dimension_pkey PRIMARY KEY (id),
+  CONSTRAINT dimension_hypertable_id_column_name_key UNIQUE (hypertable_id, column_name),
+  CONSTRAINT dimension_check CHECK ((partitioning_func_schema IS NULL AND partitioning_func IS NULL) OR (partitioning_func_schema IS NOT NULL AND partitioning_func IS NOT NULL)),
+  CONSTRAINT dimension_check1 CHECK ((num_slices IS NULL AND interval_length IS NOT NULL) OR (num_slices IS NOT NULL AND interval_length IS NULL)),
+  CONSTRAINT dimension_check2 CHECK ((integer_now_func_schema IS NULL AND integer_now_func IS NULL) OR (integer_now_func_schema IS NOT NULL AND integer_now_func IS NOT NULL)),
+  CONSTRAINT dimension_interval_length_check CHECK (interval_length IS NULL OR interval_length > 0),
+  CONSTRAINT dimension_compress_interval_length_check CHECK (compress_interval_length IS NULL OR compress_interval_length > 0),
+  CONSTRAINT dimension_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+INSERT INTO _timescaledb_catalog.dimension
+( id, hypertable_id, column_name, column_type,
+  aligned, num_slices, partitioning_func_schema,
+  partitioning_func, interval_length,
+  integer_now_func_schema, integer_now_func)
+SELECT id, hypertable_id, column_name, column_type,
+  aligned, num_slices, partitioning_func_schema,
+  partitioning_func, interval_length,
+  integer_now_func_schema, integer_now_func
+FROM _timescaledb_internal.dimension_tmp;
+
+ALTER SEQUENCE _timescaledb_catalog.dimension_id_seq OWNED BY _timescaledb_catalog.dimension.id;
+SELECT setval('_timescaledb_catalog.dimension_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_dimension_seq_value;
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension', '');
+SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_catalog.dimension', 'id'), '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.dimension_partition ADD CONSTRAINT 
+dimension_partition_dimension_id_fkey FOREIGN KEY (dimension_id) 
+REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.dimension_slice ADD CONSTRAINT
+dimension_slice_dimension_id_fkey FOREIGN KEY (dimension_id) 
+REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.dimension_tmp;
+DROP TABLE _timescaledb_internal.tmp_dimension_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.dimension_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.dimension TO PUBLIC;
+
+-- end recreate _timescaledb_catalog.dimension table --

--- a/sql/updates/reverse-dev.sql
+++ b/sql/updates/reverse-dev.sql
@@ -115,3 +115,81 @@ $BODY$
          SELECT * FROM _chunk_sizes) AS sizes;
 $BODY$ SET search_path TO pg_catalog, pg_temp;
 
+-- Recreate _timescaledb_catalog.dimension table without the compress_interval_length column --
+CREATE TABLE _timescaledb_internal.dimension_tmp
+AS SELECT * from _timescaledb_catalog.dimension;
+
+CREATE TABLE _timescaledb_internal.tmp_dimension_seq_value AS
+SELECT last_value, is_called FROM _timescaledb_catalog.dimension_id_seq;
+
+--drop foreign keys on dimension table
+ALTER TABLE _timescaledb_catalog.dimension_partition DROP CONSTRAINT 
+dimension_partition_dimension_id_fkey;
+ALTER TABLE _timescaledb_catalog.dimension_slice DROP CONSTRAINT 
+dimension_slice_dimension_id_fkey;
+
+--drop dependent views
+DROP VIEW IF EXISTS timescaledb_information.chunks;
+DROP VIEW IF EXISTS timescaledb_information.dimensions;
+
+ALTER EXTENSION timescaledb DROP TABLE _timescaledb_catalog.dimension;
+ALTER EXTENSION timescaledb DROP SEQUENCE _timescaledb_catalog.dimension_id_seq;
+DROP TABLE _timescaledb_catalog.dimension;
+
+CREATE TABLE _timescaledb_catalog.dimension (
+  id serial NOT NULL ,
+  hypertable_id integer NOT NULL,
+  column_name name NOT NULL,
+  column_type REGTYPE NOT NULL,
+  aligned boolean NOT NULL,
+  -- closed dimensions
+  num_slices smallint NULL,
+  partitioning_func_schema name NULL,
+  partitioning_func name NULL,
+  -- open dimensions (e.g., time)
+  interval_length bigint NULL,
+  integer_now_func_schema name NULL,
+  integer_now_func name NULL,
+  -- table constraints
+  CONSTRAINT dimension_pkey PRIMARY KEY (id),
+  CONSTRAINT dimension_hypertable_id_column_name_key UNIQUE (hypertable_id, column_name),
+  CONSTRAINT dimension_check CHECK ((partitioning_func_schema IS NULL AND partitioning_func IS NULL) OR (partitioning_func_schema IS NOT NULL AND partitioning_func IS NOT NULL)),
+  CONSTRAINT dimension_check1 CHECK ((num_slices IS NULL AND interval_length IS NOT NULL) OR (num_slices IS NOT NULL AND interval_length IS NULL)),
+  CONSTRAINT dimension_check2 CHECK ((integer_now_func_schema IS NULL AND integer_now_func IS NULL) OR (integer_now_func_schema IS NOT NULL AND integer_now_func IS NOT NULL)),
+  CONSTRAINT dimension_interval_length_check CHECK (interval_length IS NULL OR interval_length > 0),
+  CONSTRAINT dimension_hypertable_id_fkey FOREIGN KEY (hypertable_id) REFERENCES _timescaledb_catalog.hypertable (id) ON DELETE CASCADE
+);
+
+INSERT INTO _timescaledb_catalog.dimension
+( id, hypertable_id, column_name, column_type,
+  aligned, num_slices, partitioning_func_schema,
+  partitioning_func, interval_length,
+  integer_now_func_schema, integer_now_func)
+SELECT id, hypertable_id, column_name, column_type,
+  aligned, num_slices, partitioning_func_schema,
+  partitioning_func, interval_length,
+  integer_now_func_schema, integer_now_func
+FROM _timescaledb_internal.dimension_tmp;
+
+ALTER SEQUENCE _timescaledb_catalog.dimension_id_seq OWNED BY _timescaledb_catalog.dimension.id;
+SELECT setval('_timescaledb_catalog.dimension_id_seq', last_value, is_called) FROM _timescaledb_internal.tmp_dimension_seq_value;
+
+SELECT pg_catalog.pg_extension_config_dump('_timescaledb_catalog.dimension', '');
+SELECT pg_catalog.pg_extension_config_dump(pg_get_serial_sequence('_timescaledb_catalog.dimension', 'id'), '');
+
+--add the foreign key constraints
+ALTER TABLE _timescaledb_catalog.dimension_partition ADD CONSTRAINT 
+dimension_partition_dimension_id_fkey FOREIGN KEY (dimension_id) 
+REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE; 
+ALTER TABLE _timescaledb_catalog.dimension_slice ADD CONSTRAINT
+dimension_slice_dimension_id_fkey FOREIGN KEY (dimension_id) 
+REFERENCES _timescaledb_catalog.dimension(id) ON DELETE CASCADE;
+
+--cleanup
+DROP TABLE _timescaledb_internal.dimension_tmp;
+DROP TABLE _timescaledb_internal.tmp_dimension_seq_value;
+
+GRANT SELECT ON _timescaledb_catalog.dimension_id_seq TO PUBLIC;
+GRANT SELECT ON _timescaledb_catalog.dimension TO PUBLIC;
+
+-- end recreate _timescaledb_catalog.dimension table --

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -4617,6 +4617,107 @@ add_foreign_table_as_chunk(Oid relid, Hypertable *parent_ht)
 	chunk_add_inheritance(chunk, parent_ht);
 }
 
+void
+ts_chunk_merge_across_dimension(Chunk *chunk, const Chunk *merge_chunk, int32 dimension_id)
+{
+	const DimensionSlice *slice, *merge_slice;
+	int num_ccs, i;
+	bool dimension_slice_found = false;
+
+	if (chunk->hypertable_relid != merge_chunk->hypertable_relid)
+		ereport(ERROR,
+				(errmsg("cannot merge chunks from different hypertables"),
+				 errhint("chunk 1: \"%s\", chunk 2: \"%s\"",
+						 get_rel_name(chunk->table_id),
+						 get_rel_name(merge_chunk->table_id))));
+
+	for (int i = 0; i < chunk->cube->num_slices; i++)
+	{
+		if (chunk->cube->slices[i]->fd.dimension_id == dimension_id)
+		{
+			slice = chunk->cube->slices[i];
+			merge_slice = merge_chunk->cube->slices[i];
+			dimension_slice_found = true;
+		}
+		else if (chunk->cube->slices[i]->fd.id != merge_chunk->cube->slices[i]->fd.id)
+		{
+			/* If the slices do not match (except on time dimension), we cannot merge the chunks. */
+			ereport(ERROR,
+					(errmsg("cannot merge chunks with different partitioning schemas"),
+					 errhint("chunk 1: \"%s\", chunk 2: \"%s\" have different slices on "
+							 "dimension ID %d",
+							 get_rel_name(chunk->table_id),
+							 get_rel_name(merge_chunk->table_id),
+							 chunk->cube->slices[i]->fd.dimension_id)));
+		}
+	}
+
+	if (!dimension_slice_found)
+		ereport(ERROR,
+				(errmsg("cannot find slice for merging dimension"),
+				 errhint("chunk 1: \"%s\", chunk 2: \"%s\", dimension ID %d",
+						 get_rel_name(chunk->table_id),
+						 get_rel_name(merge_chunk->table_id),
+						 dimension_id)));
+
+	if (slice->fd.range_end != merge_slice->fd.range_start)
+		ereport(ERROR,
+				(errmsg("cannot merge non-adjacent chunks over supplied dimension"),
+				 errhint("chunk 1: \"%s\", chunk 2: \"%s\", dimension ID %d",
+						 get_rel_name(chunk->table_id),
+						 get_rel_name(merge_chunk->table_id),
+						 dimension_id)));
+
+	num_ccs =
+		ts_chunk_constraint_scan_by_dimension_slice_id(slice->fd.id, NULL, CurrentMemoryContext);
+
+	if (num_ccs <= 0)
+		ereport(ERROR,
+				(errmsg("missing chunk constraint for dimension slice"),
+				 errhint("chunk: \"%s\", slice ID %d",
+						 get_rel_name(chunk->table_id),
+						 slice->fd.id)));
+
+	DimensionSlice *new_slice =
+		ts_dimension_slice_create(dimension_id, slice->fd.range_start, merge_slice->fd.range_end);
+
+	/* Only if there is exactly one chunk constraint for the merged dimension slice
+	 * we can go ahead and delete it since we are dropping the chunk.
+	 */
+	if (num_ccs == 1)
+		ts_dimension_slice_delete_by_id(slice->fd.id, false);
+
+	ts_dimension_slice_insert(new_slice);
+	ts_chunk_constraint_update_slice_id(chunk->fd.id, slice->fd.id, new_slice->fd.id);
+	ChunkConstraints *ccs = ts_chunk_constraints_alloc(1, CurrentMemoryContext);
+	num_ccs =
+		ts_chunk_constraint_scan_by_dimension_slice_id(new_slice->fd.id, ccs, CurrentMemoryContext);
+
+	if (num_ccs <= 0)
+		ereport(ERROR,
+				(errmsg("missing chunk constraint for merged dimension slice"),
+				 errhint("chunk: \"%s\", slice ID %d",
+						 get_rel_name(chunk->table_id),
+						 new_slice->fd.id)));
+
+	/* We have to recreate the chunk constraints since we are changing
+	 * table constraints when updating the slice.
+	 */
+	for (i = 0; i < ccs->capacity; i++)
+	{
+		ChunkConstraint cc = ccs->constraints[i];
+		if (cc.fd.chunk_id == chunk->fd.id)
+		{
+			ts_process_utility_set_expect_chunk_modification(true);
+			ts_chunk_constraint_recreate(&cc, chunk->table_id);
+			ts_process_utility_set_expect_chunk_modification(false);
+			break;
+		}
+	}
+
+	ts_chunk_drop(merge_chunk, DROP_RESTRICT, 1);
+}
+
 /* Internal API used by OSM extension. OSM table is a foreign table that is
  * attached as a chunk of the hypertable. A chunk needs dimension constraints. We
  * add dummy constraints for the OSM chunk and then attach it to the hypertable.

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -231,6 +231,8 @@ extern void ts_chunk_scan_iterator_set_chunk_id(ScanIterator *it, int32 chunk_id
 extern bool ts_chunk_lock_if_exists(Oid chunk_oid, LOCKMODE chunk_lockmode);
 extern int ts_chunk_oid_cmp(const void *p1, const void *p2);
 int ts_chunk_get_osm_chunk_id(int hypertable_id);
+extern TSDLLEXPORT void ts_chunk_merge_across_dimension(Chunk *chunk, const Chunk *empty_chunk,
+														int32 dimension_id);
 
 #define chunk_get_by_name(schema_name, table_name, fail_if_not_found)                              \
 	ts_chunk_get_by_name_with_memory_context(schema_name,                                          \

--- a/src/chunk_constraint.c
+++ b/src/chunk_constraint.c
@@ -992,6 +992,51 @@ ts_chunk_constraint_adjust_meta(int32 chunk_id, const char *ht_constraint_name, 
 	return count;
 }
 
+bool
+ts_chunk_constraint_update_slice_id(int32 chunk_id, int32 old_slice_id, int32 new_slice_id)
+{
+	ScanIterator iterator =
+		ts_scan_iterator_create(CHUNK_CONSTRAINT, RowExclusiveLock, CurrentMemoryContext);
+
+	ts_chunk_constraint_scan_iterator_set_slice_id(&iterator, old_slice_id);
+
+	ts_scanner_foreach(&iterator)
+	{
+		bool nulls[Natts_chunk_constraint];
+		bool repl[Natts_chunk_constraint] = { false };
+		Datum values[Natts_chunk_constraint];
+		bool should_free, isnull;
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+		int32 current_chunk_id =
+			DatumGetInt32(slot_getattr(ti->slot, Anum_chunk_constraint_chunk_id, &isnull));
+
+		if (isnull || current_chunk_id != chunk_id)
+			continue;
+
+		HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
+		HeapTuple new_tuple;
+
+		heap_deform_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls);
+
+		values[AttrNumberGetAttrOffset(Anum_chunk_constraint_dimension_slice_id)] =
+			Int32GetDatum(new_slice_id);
+		repl[AttrNumberGetAttrOffset(Anum_chunk_constraint_dimension_slice_id)] = true;
+
+		new_tuple = heap_modify_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls, repl);
+
+		ts_catalog_update(ti->scanrel, new_tuple);
+		heap_freetuple(new_tuple);
+
+		if (should_free)
+			heap_freetuple(tuple);
+
+		ts_scan_iterator_close(&iterator);
+		return true;
+	}
+
+	return false;
+}
+
 int
 ts_chunk_constraint_rename_hypertable_constraint(int32 chunk_id, const char *oldname,
 												 const char *newname)

--- a/src/chunk_constraint.h
+++ b/src/chunk_constraint.h
@@ -77,6 +77,8 @@ extern int ts_chunk_constraint_rename_hypertable_constraint(int32 chunk_id, cons
 															const char *newname);
 extern int ts_chunk_constraint_adjust_meta(int32 chunk_id, const char *ht_constraint_name,
 										   const char *oldname, const char *newname);
+extern TSDLLEXPORT bool ts_chunk_constraint_update_slice_id(int32 chunk_id, int32 old_slice_id,
+															int32 new_slice_id);
 
 extern char *
 ts_chunk_constraint_get_name_from_hypertable_constraint(Oid chunk_relid,

--- a/src/compression_with_clause.c
+++ b/src/compression_with_clause.c
@@ -35,6 +35,10 @@ static const WithClauseDefinition compress_hypertable_with_clause_def[] = {
 			 .arg_name = "compress_orderby",
 			 .type_id = TEXTOID,
 		},
+		[CompressChunkTimeInterval] = {
+			 .arg_name = "compress_chunk_time_interval",
+			 .type_id = INTERVALOID,
+		},
 };
 
 WithClauseResult *
@@ -276,4 +280,20 @@ ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options, Hypertab
 	}
 	else
 		return NIL;
+}
+
+/* returns List of CompressedParsedCol
+ * E.g. timescaledb.compress_orderby = 'col1 asc nulls first,col2 desc,col3'
+ */
+Interval *
+ts_compress_hypertable_parse_chunk_time_interval(WithClauseResult *parsed_options,
+												 Hypertable *hypertable)
+{
+	if (parsed_options[CompressChunkTimeInterval].is_default == false)
+	{
+		Datum textarg = parsed_options[CompressChunkTimeInterval].parsed;
+		return DatumGetIntervalP(textarg);
+	}
+	else
+		return NULL;
 }

--- a/src/compression_with_clause.h
+++ b/src/compression_with_clause.h
@@ -18,6 +18,7 @@ typedef enum CompressHypertableOption
 	CompressEnabled = 0,
 	CompressSegmentBy,
 	CompressOrderBy,
+	CompressChunkTimeInterval,
 } CompressHypertableOption;
 
 typedef struct
@@ -33,5 +34,8 @@ extern TSDLLEXPORT List *ts_compress_hypertable_parse_segment_by(WithClauseResul
 																 Hypertable *hypertable);
 extern TSDLLEXPORT List *ts_compress_hypertable_parse_order_by(WithClauseResult *parsed_options,
 															   Hypertable *hypertable);
+extern TSDLLEXPORT Interval *
+ts_compress_hypertable_parse_chunk_time_interval(WithClauseResult *parsed_options,
+												 Hypertable *hypertable);
 
 #endif

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -222,8 +222,13 @@ dimension_fill_in_from_tuple(Dimension *d, TupleInfo *ti, Oid main_table_relid)
 	if (IS_CLOSED_DIMENSION(d))
 		d->fd.num_slices = DatumGetInt16(values[Anum_dimension_num_slices - 1]);
 	else
+	{
 		d->fd.interval_length =
 			DatumGetInt64(values[AttrNumberGetAttrOffset(Anum_dimension_interval_length)]);
+		if (!isnull[Anum_dimension_compress_interval_length - 1])
+			d->fd.compress_interval_length = DatumGetInt64(
+				values[AttrNumberGetAttrOffset(Anum_dimension_compress_interval_length)]);
+	}
 
 	d->column_attno = get_attnum(main_table_relid, NameStr(d->fd.column_name));
 	d->main_table_relid = main_table_relid;
@@ -745,6 +750,17 @@ dimension_tuple_update(TupleInfo *ti, void *data)
 		values[AttrNumberGetAttrOffset(Anum_dimension_interval_length)] =
 			Int64GetDatum(dim->fd.interval_length);
 
+	if (dim->fd.compress_interval_length > 0)
+	{
+		values[AttrNumberGetAttrOffset(Anum_dimension_compress_interval_length)] =
+			Int64GetDatum(dim->fd.compress_interval_length);
+		nulls[AttrNumberGetAttrOffset(Anum_dimension_compress_interval_length)] = false;
+	}
+	else
+	{
+		nulls[AttrNumberGetAttrOffset(Anum_dimension_compress_interval_length)] = true;
+	}
+
 	new_tuple = heap_form_tuple(ts_scanner_get_tupledesc(ti), values, nulls);
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	ts_catalog_update_tid(ti->scanrel, ts_scanner_get_tuple_tid(ti), new_tuple);
@@ -807,6 +823,9 @@ dimension_insert_relation(Relation rel, int32 hypertable_id, Name colname, Oid c
 	/* no integer_now function by default */
 	nulls[AttrNumberGetAttrOffset(Anum_dimension_integer_now_func_schema)] = true;
 	nulls[AttrNumberGetAttrOffset(Anum_dimension_integer_now_func)] = true;
+
+	/* no compress interval length by default */
+	nulls[AttrNumberGetAttrOffset(Anum_dimension_compress_interval_length)] = true;
 
 	ts_catalog_database_info_become_owner(ts_catalog_database_info_get(), &sec_ctx);
 	dimension_id = Int32GetDatum(ts_catalog_table_next_seq_id(ts_catalog_get(), DIMENSION));
@@ -875,6 +894,21 @@ ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval)
 	Assert(IS_OPEN_DIMENSION(dim));
 
 	dim->fd.interval_length = chunk_interval;
+
+	return dimension_scan_update(dim->fd.id, dimension_tuple_update, dim, RowExclusiveLock);
+}
+
+int
+ts_dimension_set_compress_interval(Dimension *dim, int64 compress_interval)
+{
+	if (!IS_OPEN_DIMENSION(dim))
+		ereport(ERROR,
+				(errmsg("trying to set compress interval on closed dimension"),
+				 errhint("dimension ID %d", dim->fd.id)));
+
+	Assert(IS_OPEN_DIMENSION(dim));
+
+	dim->fd.compress_interval_length = compress_interval;
 
 	return dimension_scan_update(dim->fd.id, dimension_tuple_update, dim, RowExclusiveLock);
 }

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -125,6 +125,7 @@ extern int ts_dimension_set_type(Dimension *dim, Oid newtype);
 extern TSDLLEXPORT Oid ts_dimension_get_partition_type(const Dimension *dim);
 extern int ts_dimension_set_name(Dimension *dim, const char *newname);
 extern int ts_dimension_set_chunk_interval(Dimension *dim, int64 chunk_interval);
+extern int ts_dimension_set_compress_interval(Dimension *dim, int64 compress_chunk_interval);
 extern TSDLLEXPORT int ts_dimension_set_number_of_slices(Dimension *dim, int16 num_slices);
 extern Datum ts_dimension_transform_value(const Dimension *dim, Oid collation, Datum value,
 										  Oid const_datum_type, Oid *restype);

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -975,6 +975,19 @@ ts_dimension_slice_insert_multi(DimensionSlice **slices, Size num_slices)
 	return n;
 }
 
+void
+ts_dimension_slice_insert(DimensionSlice *slice)
+{
+	Catalog *catalog = ts_catalog_get();
+	Relation rel;
+
+	rel = table_open(catalog_get_table_id(catalog, DIMENSION_SLICE), RowExclusiveLock);
+
+	dimension_slice_insert_relation(rel, slice);
+
+	table_close(rel, RowExclusiveLock);
+}
+
 static ScanTupleResult
 dimension_slice_nth_tuple_found(TupleInfo *ti, void *data)
 {

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -75,6 +75,7 @@ extern bool ts_dimension_slice_cut(DimensionSlice *to_cut, const DimensionSlice 
 								   int64 coord);
 extern void ts_dimension_slice_free(DimensionSlice *slice);
 extern int ts_dimension_slice_insert_multi(DimensionSlice **slice, Size num_slices);
+extern void ts_dimension_slice_insert(DimensionSlice *slice);
 extern int ts_dimension_slice_cmp(const DimensionSlice *left, const DimensionSlice *right);
 extern int ts_dimension_slice_cmp_coordinate(const DimensionSlice *slice, int64 coord);
 

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -2533,6 +2533,18 @@ ts_hypertable_unset_compressed(Hypertable *ht)
 	return ts_hypertable_update(ht) > 0;
 }
 
+bool
+ts_hypertable_set_compress_interval(Hypertable *ht, int64 compress_interval)
+{
+	Assert(!TS_HYPERTABLE_IS_INTERNAL_COMPRESSION_TABLE(ht));
+	Assert(TS_HYPERTABLE_HAS_COMPRESSION_ENABLED(ht));
+
+	Dimension *time_dimension =
+		ts_hyperspace_get_mutable_dimension(ht->space, DIMENSION_TYPE_OPEN, 0);
+
+	return ts_dimension_set_compress_interval(time_dimension, compress_interval) > 0;
+}
+
 /* create a compressed hypertable
  * table_relid - already created table which we are going to
  *               set up as a compressed hypertable

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -149,6 +149,8 @@ extern bool ts_is_partitioning_column(const Hypertable *ht, Index column_attno);
 extern TSDLLEXPORT bool ts_hypertable_set_compressed(Hypertable *ht,
 													 int32 compressed_hypertable_id);
 extern TSDLLEXPORT bool ts_hypertable_unset_compressed(Hypertable *ht);
+extern TSDLLEXPORT bool ts_hypertable_set_compress_interval(Hypertable *ht,
+															int64 compress_interval);
 extern TSDLLEXPORT void ts_hypertable_clone_constraints_to_compressed(const Hypertable *ht,
 																	  List *constraint_list);
 extern List *ts_hypertable_assign_chunk_data_nodes(const Hypertable *ht, const Hypercube *cube);

--- a/src/ts_catalog/catalog.h
+++ b/src/ts_catalog/catalog.h
@@ -241,6 +241,7 @@ enum Anum_dimension
 	Anum_dimension_partitioning_func_schema,
 	Anum_dimension_partitioning_func,
 	Anum_dimension_interval_length,
+	Anum_dimension_compress_interval_length,
 	Anum_dimension_integer_now_func_schema,
 	Anum_dimension_integer_now_func,
 	_Anum_dimension_max,
@@ -261,6 +262,7 @@ typedef struct FormData_dimension
 	NameData partitioning_func;
 	/* open (time) columns */
 	int64 interval_length;
+	int64 compress_interval_length;
 	NameData integer_now_func_schema;
 	NameData integer_now_func;
 } FormData_dimension;

--- a/test/expected/chunk_adaptive.out
+++ b/test/expected/chunk_adaptive.out
@@ -82,9 +82,9 @@ FROM _timescaledb_catalog.hypertable;
 -- Check that adaptive chunking sets a 1 day default chunk time
 -- interval => 86400000000 microseconds
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  2 |             2 | time        | timestamp with time zone | t       |            |                          |                   |     86400000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  2 |             2 | time        | timestamp with time zone | t       |            |                          |                   |     86400000000 |                          |                         | 
 (1 row)
 
 -- Change the target size

--- a/test/expected/create_chunks.out
+++ b/test/expected/create_chunks.out
@@ -82,10 +82,10 @@ SELECT set_chunk_time_interval('chunk_test', 5::bigint);
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  2 |             1 | tag         | integer     | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  1 |             1 | time        | integer     | t       |            |                          |                    |               5 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  2 |             1 | tag         | integer     | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  1 |             1 | time        | integer     | t       |            |                          |                    |               5 |                          |                         | 
 (2 rows)
 
 INSERT INTO chunk_test VALUES (7, 24.3, 79669, 1);

--- a/test/expected/create_hypertable.out
+++ b/test/expected/create_hypertable.out
@@ -92,13 +92,13 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
-  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
-  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  5 |             2 | location    | text        | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
+  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  5 |             2 | location    | text        | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (5 rows)
 
 --test that we can change the number of partitions and that 1 is allowed
@@ -109,9 +109,9 @@ SELECT set_number_partitions('test_schema.test_table', 1, 'location');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE column_name = 'location';
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  5 |             2 | location    | text        | f       |          1 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  5 |             2 | location    | text        | f       |          1 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (1 row)
 
 SELECT set_number_partitions('test_schema.test_table', 2, 'location');
@@ -121,9 +121,9 @@ SELECT set_number_partitions('test_schema.test_table', 2, 'location');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE column_name = 'location';
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -155,14 +155,14 @@ select * from _timescaledb_catalog.hypertable where table_name = 'test_table';
 (1 row)
 
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
-  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                         | 
-  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  6 |             2 | id          | integer     | t       |            |                          |                    |            1000 |                         | 
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
+  2 |             1 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time        | bigint      | t       |            |                          |                    |   2592000000000 |                          |                         | 
+  4 |             2 | device_id   | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  5 |             2 | location    | text        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  6 |             2 | id          | integer     | t       |            |                          |                    |            1000 |                          |                         | 
 (6 rows)
 
 -- Test add_dimension: can use interval types for TIMESTAMPTZ columns
@@ -757,9 +757,9 @@ select set_integer_now_func('test_table_int', 'dummy_now');
 (1 row)
 
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
- 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 | public                  | dummy_now
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+ 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 |                          | public                  | dummy_now
 (1 row)
 
 \set ON_ERROR_STOP 0
@@ -779,9 +779,9 @@ select set_integer_now_func('test_table_int', 'my_user_schema.dummy_now4', repla
 \c :TEST_DBNAME :ROLE_SUPERUSER
 ALTER SCHEMA my_user_schema RENAME TO my_new_schema;
 select * from _timescaledb_catalog.dimension WHERE hypertable_id = :TEST_TABLE_INT_HYPERTABLE_ID;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
- 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 | my_new_schema           | dummy_now4
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+ 29 |            17 | time        | bigint      | t       |            |                          |                   |               1 |                          | my_new_schema           | dummy_now4
 (1 row)
 
 -- github issue #4650

--- a/test/expected/ddl-12.out
+++ b/test/expected/ddl-12.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/ddl-13.out
+++ b/test/expected/ddl-13.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/ddl-14.out
+++ b/test/expected/ddl-14.out
@@ -422,10 +422,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 -- show the column name and type of the partitioning dimension in the
 -- metadata table
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | color       | character varying        | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time        | timestamp with time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 EXPLAIN (costs off)
@@ -476,10 +476,10 @@ SELECT * FROM test.show_columnsp('_timescaledb_internal._hyper_9_%chunk');
 
 -- show that the metadata has been updated
 SELECT * FROM _timescaledb_catalog.dimension WHERE hypertable_id = 9;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
- 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
- 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+ 15 |             9 | colorname   | character varying           | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+ 14 |             9 | time_us     | timestamp without time zone | t       |            |                          |                    |   2628000000000 |                          |                         | 
 (2 rows)
 
 -- constraint exclusion should still work with updated column

--- a/test/expected/drop_hypertable.out
+++ b/test/expected/drop_hypertable.out
@@ -7,8 +7,8 @@ SELECT * from _timescaledb_catalog.hypertable;
 (0 rows)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
 (0 rows)
 
 CREATE TABLE should_drop (time timestamp, temp float8);
@@ -82,9 +82,9 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
 (1 row)
 
 DROP TABLE should_drop;
@@ -105,8 +105,8 @@ SELECT * from _timescaledb_catalog.hypertable;
 (1 row)
 
 SELECT * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  4 |             4 | time        | timestamp without time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
 (1 row)
 

--- a/test/expected/drop_owned.out
+++ b/test/expected/drop_owned.out
@@ -64,8 +64,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/drop_schema.out
+++ b/test/expected/drop_schema.out
@@ -96,8 +96,8 @@ SELECT * FROM _timescaledb_catalog.chunk;
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
+ id | hypertable_id | column_name | column_type | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
 (0 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension_slice;

--- a/test/expected/partition.out
+++ b/test/expected/partition.out
@@ -11,10 +11,10 @@ NOTICE:  adding not-null constraint to column "time"
 
 -- Show legacy partitioning function is used
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (2 rows)
 
 INSERT INTO part_legacy VALUES ('2017-03-22T09:18:23', 23.4, 1);
@@ -54,12 +54,12 @@ NOTICE:  adding not-null constraint to column "time"
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
-  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  4 |             2 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
+  3 |             2 | time        | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  4 |             2 | device      | integer                  | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
 (4 rows)
 
 INSERT INTO part_new VALUES ('2017-03-22T09:18:23', 23.4, 1);
@@ -133,17 +133,17 @@ SELECT add_dimension('part_add_dim', 'location', 2, partitioning_func => '_times
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
-  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
-  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000 |                         | 
-  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
+  3 |             2 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
+  4 |             2 | device      | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  6 |             3 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  5 |             3 | time        | timestamp without time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  7 |             4 | time        | timestamp with time zone    | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             4 | temp        | double precision            | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             4 | location    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 -- Test that we support custom SQL-based partitioning functions and

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -31,6 +31,7 @@
 #include "debug_point.h"
 #include "errors.h"
 #include "error_utils.h"
+#include "hypercube.h"
 #include "hypertable.h"
 #include "hypertable_cache.h"
 #include "ts_catalog/continuous_agg.h"
@@ -94,6 +95,86 @@ compression_chunk_size_catalog_insert(int32 src_chunk_id, const RelationSize *sr
 	ts_catalog_insert_values(rel, desc, values, nulls);
 	ts_catalog_restore_user(&sec_ctx);
 	table_close(rel, RowExclusiveLock);
+}
+
+static int
+compression_chunk_size_catalog_update_merged(int32 chunk_id, const RelationSize *size,
+											 int32 merge_chunk_id, const RelationSize *merge_size,
+											 int64 merge_rowcnt_pre_compression,
+											 int64 merge_rowcnt_post_compression)
+{
+	ScanIterator iterator =
+		ts_scan_iterator_create(COMPRESSION_CHUNK_SIZE, RowExclusiveLock, CurrentMemoryContext);
+	bool updated = false;
+
+	iterator.ctx.index =
+		catalog_get_index(ts_catalog_get(), COMPRESSION_CHUNK_SIZE, COMPRESSION_CHUNK_SIZE_PKEY);
+	ts_scan_iterator_scan_key_init(&iterator,
+								   Anum_compression_chunk_size_pkey_chunk_id,
+								   BTEqualStrategyNumber,
+								   F_INT4EQ,
+								   Int32GetDatum(chunk_id));
+	ts_scanner_foreach(&iterator)
+	{
+		Datum values[Natts_compression_chunk_size];
+		bool repl[Natts_compression_chunk_size] = { false };
+		bool nulls[Natts_compression_chunk_size] = { false };
+		bool should_free;
+		TupleInfo *ti = ts_scan_iterator_tuple_info(&iterator);
+		HeapTuple tuple = ts_scanner_fetch_heap_tuple(ti, false, &should_free);
+		HeapTuple new_tuple;
+		heap_deform_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls);
+
+		/* Increment existing sizes with sizes from uncompressed chunk. */
+		values[AttrNumberGetAttrOffset(Anum_compression_chunk_size_uncompressed_heap_size)] =
+			Int64GetDatum(size->heap_size +
+						  DatumGetInt64(values[AttrNumberGetAttrOffset(
+							  Anum_compression_chunk_size_uncompressed_heap_size)]));
+		repl[AttrNumberGetAttrOffset(Anum_compression_chunk_size_uncompressed_heap_size)] = true;
+		values[AttrNumberGetAttrOffset(Anum_compression_chunk_size_uncompressed_toast_size)] =
+			Int64GetDatum(size->toast_size +
+						  DatumGetInt64(values[AttrNumberGetAttrOffset(
+							  Anum_compression_chunk_size_uncompressed_toast_size)]));
+		repl[AttrNumberGetAttrOffset(Anum_compression_chunk_size_uncompressed_toast_size)] = true;
+		values[AttrNumberGetAttrOffset(Anum_compression_chunk_size_uncompressed_index_size)] =
+			Int64GetDatum(size->index_size +
+						  DatumGetInt64(values[AttrNumberGetAttrOffset(
+							  Anum_compression_chunk_size_uncompressed_index_size)]));
+		repl[AttrNumberGetAttrOffset(Anum_compression_chunk_size_uncompressed_index_size)] = true;
+		values[AttrNumberGetAttrOffset(Anum_compression_chunk_size_compressed_heap_size)] =
+			Int64GetDatum(merge_size->heap_size);
+		repl[AttrNumberGetAttrOffset(Anum_compression_chunk_size_compressed_heap_size)] = true;
+		values[AttrNumberGetAttrOffset(Anum_compression_chunk_size_compressed_toast_size)] =
+			Int64GetDatum(merge_size->toast_size);
+		repl[AttrNumberGetAttrOffset(Anum_compression_chunk_size_compressed_toast_size)] = true;
+		values[AttrNumberGetAttrOffset(Anum_compression_chunk_size_compressed_index_size)] =
+			Int64GetDatum(merge_size->index_size);
+		repl[AttrNumberGetAttrOffset(Anum_compression_chunk_size_compressed_index_size)] = true;
+		values[AttrNumberGetAttrOffset(Anum_compression_chunk_size_numrows_pre_compression)] =
+			Int64GetDatum(merge_rowcnt_pre_compression +
+						  DatumGetInt64(values[AttrNumberGetAttrOffset(
+							  Anum_compression_chunk_size_numrows_pre_compression)]));
+		repl[AttrNumberGetAttrOffset(Anum_compression_chunk_size_numrows_pre_compression)] = true;
+		values[AttrNumberGetAttrOffset(Anum_compression_chunk_size_numrows_post_compression)] =
+			Int64GetDatum(merge_rowcnt_post_compression +
+						  DatumGetInt64(values[AttrNumberGetAttrOffset(
+							  Anum_compression_chunk_size_numrows_post_compression)]));
+		repl[AttrNumberGetAttrOffset(Anum_compression_chunk_size_numrows_post_compression)] = true;
+
+		new_tuple = heap_modify_tuple(tuple, ts_scanner_get_tupledesc(ti), values, nulls, repl);
+		ts_catalog_update(ti->scanrel, new_tuple);
+		heap_freetuple(new_tuple);
+
+		if (should_free)
+			heap_freetuple(tuple);
+
+		updated = true;
+		break;
+	}
+
+	ts_scan_iterator_end(&iterator);
+	ts_scan_iterator_close(&iterator);
+	return updated;
 }
 
 static void
@@ -199,11 +280,133 @@ restore_autovacuum_on_decompress(Oid uncompressed_hypertable_relid, Oid uncompre
 	}
 }
 
-static void
+Chunk *
+find_chunk_to_merge_into(Hypertable *ht, Chunk *current_chunk)
+{
+	int64 compressed_chunk_interval;
+	int64 max_chunk_interval;
+	int64 current_chunk_interval;
+	const Dimension *time_dim;
+	Chunk *previous_chunk;
+	Point *p;
+	int64 val;
+	time_dim = hyperspace_get_open_dimension(ht->space, 0);
+	if (!time_dim)
+		elog(ERROR, "hypertable has no open partitioning dimension");
+
+	if (time_dim->fd.compress_interval_length == 0)
+	{
+		return NULL;
+	}
+
+	max_chunk_interval = time_dim->fd.compress_interval_length;
+
+	p = ts_point_create(current_chunk->cube->num_slices);
+	current_chunk_interval = 0;
+	for (int i = 0; i < current_chunk->cube->num_slices; i++)
+	{
+		val = current_chunk->cube->slices[i]->fd.range_start;
+		if (current_chunk->cube->slices[i]->fd.dimension_id == time_dim->fd.id)
+		{
+			current_chunk_interval = current_chunk->cube->slices[i]->fd.range_end -
+									 current_chunk->cube->slices[i]->fd.range_start;
+			val--;
+		}
+		p->coordinates[p->num_coords++] = val;
+	}
+
+	if (current_chunk_interval == 0)
+	{
+		return NULL;
+	}
+
+	previous_chunk = ts_hypertable_find_chunk_for_point(ht, p);
+
+	/* If there is no previous adjacent chunk along the time dimension or
+	 * if it hasn't been compressed yet, we can't merge.
+	 */
+	if (!previous_chunk || previous_chunk->fd.compressed_chunk_id == InvalidOid)
+	{
+		return NULL;
+	}
+
+	compressed_chunk_interval = 0;
+	for (int i = 0; i < previous_chunk->cube->num_slices; i++)
+	{
+		if (previous_chunk->cube->slices[i]->fd.dimension_id == time_dim->fd.id)
+		{
+			compressed_chunk_interval = previous_chunk->cube->slices[i]->fd.range_end -
+										previous_chunk->cube->slices[i]->fd.range_start;
+		}
+		else if (previous_chunk->cube->slices[i]->fd.id != current_chunk->cube->slices[i]->fd.id)
+		{
+			/* If the slices do not match (except on time dimension), we cannot merge the chunks. */
+			return NULL;
+		}
+	}
+
+	/* If the compressed chunk is full, we can't merge any more. */
+	if (compressed_chunk_interval == 0 ||
+		compressed_chunk_interval + current_chunk_interval > max_chunk_interval)
+	{
+		return NULL;
+	}
+
+	return previous_chunk;
+}
+
+/* Check if compression order is violated by merging in a new chunk
+ * Because data merged in uses higher sequence numbers than any data already in the chunk,
+ * the only way the order is guaranteed can be if we know the data we are merging in would come
+ * after the existing data according to the compression order. This is true if the data being merged
+ * in has timestamps greater than the existing data and the first column in the order by is time
+ * ASC.
+ */
+bool
+check_is_chunk_order_violated_by_merge(
+	const Dimension *time_dim, Chunk *mergable_chunk, Chunk *compressed_chunk,
+	const FormData_hypertable_compression **column_compression_info, int num_compression_infos)
+{
+	const DimensionSlice *mergable_slice =
+		ts_hypercube_get_slice_by_dimension_id(mergable_chunk->cube, time_dim->fd.id);
+	if (!mergable_slice)
+		elog(ERROR, "mergable chunk has no time dimension slice");
+	const DimensionSlice *compressed_slice =
+		ts_hypercube_get_slice_by_dimension_id(compressed_chunk->cube, time_dim->fd.id);
+	if (!compressed_slice)
+		elog(ERROR, "compressed chunk has no time dimension slice");
+
+	if (mergable_slice->fd.range_start > compressed_slice->fd.range_start &&
+		mergable_slice->fd.range_end > compressed_slice->fd.range_start)
+	{
+		return true;
+	}
+
+	for (int i = 0; i < num_compression_infos; i++)
+	{
+		if (column_compression_info[i]->orderby_column_index == 1)
+		{
+			if (!column_compression_info[i]->orderby_asc)
+			{
+				return true;
+			}
+			if (get_attnum(time_dim->main_table_relid,
+						   NameStr(column_compression_info[i]->attname)) != time_dim->column_attno)
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+static Oid
 compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 {
+	Oid result_chunk_id = chunk_relid;
 	CompressChunkCxt cxt;
-	Chunk *compress_ht_chunk;
+	Chunk *compress_ht_chunk, *mergable_chunk;
 	Cache *hcache;
 	ListCell *lc;
 	List *htcols_list = NIL;
@@ -211,6 +414,7 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 	int i = 0, htcols_listlen;
 	RelationSize before_size, after_size;
 	CompressionStats cstat;
+	bool new_compressed_chunk = false;
 
 	hcache = ts_hypertable_cache_pin();
 	compresschunkcxt_init(&cxt, hcache, hypertable_relid, chunk_relid);
@@ -247,8 +451,19 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 	/* get compression properties for hypertable */
 	htcols_list = ts_hypertable_compression_get(cxt.srcht->fd.id);
 	htcols_listlen = list_length(htcols_list);
-	/* create compressed chunk and a new table */
-	compress_ht_chunk = create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, InvalidOid);
+	mergable_chunk = find_chunk_to_merge_into(cxt.srcht, cxt.srcht_chunk);
+	if (!mergable_chunk)
+	{
+		/* create compressed chunk and a new table */
+		compress_ht_chunk = create_compress_chunk(cxt.compress_ht, cxt.srcht_chunk, InvalidOid);
+		new_compressed_chunk = true;
+	}
+	else
+	{
+		/* use an existing compressed chunk to compress into */
+		compress_ht_chunk = ts_chunk_get_by_id(mergable_chunk->fd.compressed_chunk_id, true);
+		result_chunk_id = mergable_chunk->table_id;
+	}
 	/* convert list to array of pointers for compress_chunk */
 	colinfo_array = palloc(sizeof(ColumnCompressionInfo *) * htcols_listlen);
 	foreach (lc, htcols_list)
@@ -262,32 +477,65 @@ compress_chunk_impl(Oid hypertable_relid, Oid chunk_relid)
 						   colinfo_array,
 						   htcols_listlen);
 
-	/* Copy chunk constraints (including fkey) to compressed chunk.
-	 * Do this after compressing the chunk to avoid holding strong, unnecessary locks on the
-	 * referenced table during compression.
-	 */
-	ts_chunk_constraints_create(compress_ht_chunk->constraints,
-								compress_ht_chunk->table_id,
-								compress_ht_chunk->fd.id,
-								compress_ht_chunk->hypertable_relid,
-								compress_ht_chunk->fd.hypertable_id);
-	ts_trigger_create_all_on_chunk(compress_ht_chunk);
-
 	/* Drop all FK constraints on the uncompressed chunk. This is needed to allow
 	 * cascading deleted data in FK-referenced tables, while blocking deleting data
 	 * directly on the hypertable or chunks.
 	 */
 	ts_chunk_drop_fks(cxt.srcht_chunk);
 	after_size = ts_relation_size_impl(compress_ht_chunk->table_id);
-	compression_chunk_size_catalog_insert(cxt.srcht_chunk->fd.id,
-										  &before_size,
-										  compress_ht_chunk->fd.id,
-										  &after_size,
-										  cstat.rowcnt_pre_compression,
-										  cstat.rowcnt_post_compression);
 
-	ts_chunk_set_compressed_chunk(cxt.srcht_chunk, compress_ht_chunk->fd.id);
+	if (new_compressed_chunk)
+	{
+		compression_chunk_size_catalog_insert(cxt.srcht_chunk->fd.id,
+											  &before_size,
+											  compress_ht_chunk->fd.id,
+											  &after_size,
+											  cstat.rowcnt_pre_compression,
+											  cstat.rowcnt_post_compression);
+
+		/* Copy chunk constraints (including fkey) to compressed chunk.
+		 * Do this after compressing the chunk to avoid holding strong, unnecessary locks on the
+		 * referenced table during compression.
+		 */
+		ts_chunk_constraints_create(compress_ht_chunk->constraints,
+									compress_ht_chunk->table_id,
+									compress_ht_chunk->fd.id,
+									compress_ht_chunk->hypertable_relid,
+									compress_ht_chunk->fd.hypertable_id);
+		ts_trigger_create_all_on_chunk(compress_ht_chunk);
+		ts_chunk_set_compressed_chunk(cxt.srcht_chunk, compress_ht_chunk->fd.id);
+	}
+	else
+	{
+		compression_chunk_size_catalog_update_merged(mergable_chunk->fd.id,
+													 &before_size,
+													 compress_ht_chunk->fd.id,
+													 &after_size,
+													 cstat.rowcnt_pre_compression,
+													 cstat.rowcnt_post_compression);
+
+		const Dimension *time_dim = hyperspace_get_open_dimension(cxt.srcht->space, 0);
+		if (!time_dim)
+			elog(ERROR, "hypertable has no open partitioning dimension");
+
+		bool chunk_unordered = check_is_chunk_order_violated_by_merge(time_dim,
+																	  mergable_chunk,
+																	  cxt.srcht_chunk,
+																	  colinfo_array,
+																	  htcols_listlen);
+
+		merge_chunk_relstats(mergable_chunk->table_id, cxt.srcht_chunk->table_id);
+		ts_chunk_merge_across_dimension(mergable_chunk, cxt.srcht_chunk, time_dim->fd.id);
+
+		if (chunk_unordered)
+		{
+			ts_chunk_set_unordered(mergable_chunk);
+			tsl_recompress_chunk_wrapper(mergable_chunk);
+		}
+	}
+
 	ts_cache_release(hcache);
+	return result_chunk_id;
 }
 
 static bool
@@ -410,7 +658,7 @@ decompress_chunk_impl(Oid uncompressed_hypertable_relid, Oid uncompressed_chunk_
  * already compressed, unless it is running in idempotent mode.
  */
 
-void
+Oid
 tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed)
 {
 	if (chunk->fd.compressed_chunk_id != INVALID_CHUNK_ID)
@@ -418,10 +666,10 @@ tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed)
 		ereport((if_not_compressed ? NOTICE : ERROR),
 				(errcode(ERRCODE_DUPLICATE_OBJECT),
 				 errmsg("chunk \"%s\" is already compressed", get_rel_name(chunk->table_id))));
-		return;
+		return chunk->table_id;
 	}
 
-	compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
+	return compress_chunk_impl(chunk->hypertable_relid, chunk->table_id);
 }
 
 /*
@@ -590,7 +838,7 @@ tsl_compress_chunk(PG_FUNCTION_ARGS)
 	}
 	else
 	{
-		tsl_compress_chunk_wrapper(chunk, if_not_compressed);
+		uncompressed_chunk_id = tsl_compress_chunk_wrapper(chunk, if_not_compressed);
 	}
 
 	PG_RETURN_OID(uncompressed_chunk_id);

--- a/tsl/src/compression/api.h
+++ b/tsl/src/compression/api.h
@@ -9,11 +9,15 @@
 #include <postgres.h>
 #include <fmgr.h>
 
+extern Chunk *find_chunk_to_merge_into(Hypertable *ht, Chunk *current_chunk);
+extern bool check_is_chunk_order_violated_by_merge(
+	const Dimension *time_dim, Chunk *mergable_chunk, Chunk *compressed_chunk,
+	const FormData_hypertable_compression **column_compression_info, int num_compression_infos);
 extern Datum tsl_create_compressed_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_compress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_decompress_chunk(PG_FUNCTION_ARGS);
 extern Datum tsl_recompress_chunk(PG_FUNCTION_ARGS);
-extern void tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed);
+extern Oid tsl_compress_chunk_wrapper(Chunk *chunk, bool if_not_compressed);
 extern bool tsl_recompress_chunk_wrapper(Chunk *chunk);
 
 #endif /* TIMESCALEDB_TSL_COMPRESSION_API_H */

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -151,6 +151,7 @@ extern void decompress_chunk(Oid in_table, Oid out_table);
 extern DecompressionIterator *(*tsl_get_decompression_iterator_init(
 	CompressionAlgorithms algorithm, bool reverse))(Datum, Oid element_type);
 extern void update_compressed_chunk_relstats(Oid uncompressed_relid, Oid compressed_relid);
+extern void merge_chunk_relstats(Oid compressed_relid, Oid merged_relid);
 
 /* CompressSingleRowState methods */
 struct CompressSingleRowState;

--- a/tsl/test/expected/bgw_policy.out
+++ b/tsl/test/expected/bgw_policy.out
@@ -588,14 +588,14 @@ select remove_retention_policy('part_time_now_func');
 alter function dummy_now() rename to dummy_now_renamed;
 alter schema public rename to new_public;
 select * from  _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                    |    604800000000 |                         | 
-  2 |             1 | chunk_id    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  5 |             4 | time        | timestamp without time zone | t       |            |                          |                    |               1 |                         | 
-  6 |             5 | time        | double precision            | t       |            | new_public               | time_partfunc      |               1 | new_public              | dummy_now
-  3 |             2 | time        | bigint                      | t       |            |                          |                    |               1 | new_public              | nowstamp
-  4 |             3 | time        | smallint                    | t       |            |                          |                    |               1 | new_public              | overflow_now
+ id | hypertable_id | column_name |         column_type         | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+-----------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone    | t       |            |                          |                    |    604800000000 |                          |                         | 
+  2 |             1 | chunk_id    | integer                     | f       |          2 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  5 |             4 | time        | timestamp without time zone | t       |            |                          |                    |               1 |                          |                         | 
+  6 |             5 | time        | double precision            | t       |            | new_public               | time_partfunc      |               1 |                          | new_public              | dummy_now
+  3 |             2 | time        | bigint                      | t       |            |                          |                    |               1 |                          | new_public              | nowstamp
+  4 |             3 | time        | smallint                    | t       |            |                          |                    |               1 |                          | new_public              | overflow_now
 (6 rows)
 
 alter schema new_public rename to public;

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -1,0 +1,226 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\ir include/rand_generator.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+--------------------------
+-- cheap rand generator --
+--------------------------
+create table rand_minstd_state(i bigint);
+create function rand_minstd_advance(bigint) returns bigint
+language sql immutable as
+$$
+	select (16807 * $1) % 2147483647
+$$;
+create function gen_rand_minstd() returns bigint
+language sql security definer as
+$$
+	update rand_minstd_state set i = rand_minstd_advance(i) returning i
+$$;
+-- seed the random num generator
+insert into rand_minstd_state values (321);
+\c :TEST_DBNAME :ROLE_SUPERUSER
+\ir include/compression_utils.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
+SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test1
+(1 row)
+
+-- This will generate 24 chunks
+INSERT INTO test1 SELECT t, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+-- Compression is set to merge those 24 chunks into 12 2 hour chunks
+ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+SELECT
+  $$
+  SELECT * FROM test1 ORDER BY "Time"
+  $$ AS "QUERY" \gset
+SELECT 'test1' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+psql:include/compression_test_merge.sql:7: NOTICE:  table "merge_result" does not exist, skipping
+ count_compressed 
+------------------
+               24
+(1 row)
+
+                                     ?column?                                      | count 
+-----------------------------------------------------------------------------------+-------
+ Number of rows different between original and query on compressed data (expect 0) |     0
+(1 row)
+
+ count_decompressed 
+--------------------
+                 12
+(1 row)
+
+                                                   ?column?                                                   | count 
+--------------------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+(1 row)
+
+\set TYPE timestamptz
+\set ORDER_BY_COL_NAME Time
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               12
+(1 row)
+
+ min_correct | max_correct 
+-------------+-------------
+ t           | t
+(1 row)
+
+DROP TABLE test1;
+CREATE TABLE test2 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test2
+(1 row)
+
+-- This will generate 24 1 hour chunks.
+INSERT INTO test2 SELECT t, gen_rand_minstd(), gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+-- Compression is set to merge those 24 chunks into 3 chunks, two 10 hour chunks and a single 4 hour chunk.
+ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='10 hours');
+SELECT
+  $$
+  SELECT * FROM test2 ORDER BY "Time"
+  $$ AS "QUERY" \gset
+SELECT 'test2' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               24
+(1 row)
+
+                                     ?column?                                      | count 
+-----------------------------------------------------------------------------------+-------
+ Number of rows different between original and query on compressed data (expect 0) |     0
+(1 row)
+
+ count_decompressed 
+--------------------
+                  3
+(1 row)
+
+                                                   ?column?                                                   | count 
+--------------------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+(1 row)
+
+\set TYPE integer
+\set ORDER_BY_COL_NAME loc
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+                3
+(1 row)
+
+ min_correct | max_correct 
+-------------+-------------
+ t           | t
+(1 row)
+
+DROP TABLE test2;
+CREATE TABLE test3 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test3', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+NOTICE:  adding not-null constraint to column "Time"
+ table_name 
+------------
+ test3
+(1 row)
+
+SELECT table_name from  add_dimension('test3', 'i', chunk_time_interval=> 1);
+NOTICE:  adding not-null constraint to column "i"
+ table_name 
+------------
+ test3
+(1 row)
+
+-- This will generate 25 1 hour chunks with a closed space dimension.
+INSERT INTO test3 SELECT t, 1, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 12:59', '1 minute') t;
+INSERT INTO test3 SELECT t, 2, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 13:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+INSERT INTO test3 SELECT t, 3, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 2:00'::TIMESTAMPTZ, '2018-03-02 2:01', '1 minute') t;
+-- Compression is set to merge those 25 chunks into 12 2 hour chunks and a single 1 hour chunks on a different space dimensions.
+ALTER TABLE test3 set (timescaledb.compress, timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+SELECT
+  $$
+  SELECT * FROM test3 WHERE i = 1 ORDER BY "Time"
+  $$ AS "QUERY" \gset
+SELECT 'test3' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               25
+(1 row)
+
+                                     ?column?                                      | count 
+-----------------------------------------------------------------------------------+-------
+ Number of rows different between original and query on compressed data (expect 0) |     0
+(1 row)
+
+ count_decompressed 
+--------------------
+                 13
+(1 row)
+
+                                                   ?column?                                                   | count 
+--------------------------------------------------------------------------------------------------------------+-------
+ Number of rows different between original and data that has been compressed and then decompressed (expect 0) |     0
+(1 row)
+
+\set TYPE integer
+\set ORDER_BY_COL_NAME loc
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+\set ECHO errors
+ count_compressed 
+------------------
+               13
+(1 row)
+
+ min_correct | max_correct 
+-------------+-------------
+ t           | t
+(1 row)
+
+DROP TABLE test3;

--- a/tsl/test/expected/dist_hypertable-12.out
+++ b/tsl/test/expected/dist_hypertable-12.out
@@ -2138,13 +2138,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2173,13 +2173,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2207,13 +2207,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2241,13 +2241,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2369,17 +2369,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2389,17 +2389,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2409,47 +2409,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -3419,9 +3419,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3429,9 +3429,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3439,9 +3439,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3469,10 +3469,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3480,10 +3480,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3491,10 +3491,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3535,10 +3535,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3546,10 +3546,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3557,10 +3557,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-13.out
+++ b/tsl/test/expected/dist_hypertable-13.out
@@ -2137,13 +2137,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2172,13 +2172,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2206,13 +2206,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2240,13 +2240,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2368,17 +2368,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2388,17 +2388,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2408,47 +2408,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -3418,9 +3418,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3428,9 +3428,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3438,9 +3438,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3468,10 +3468,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3479,10 +3479,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3490,10 +3490,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3534,10 +3534,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3545,10 +3545,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3556,10 +3556,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 

--- a/tsl/test/expected/dist_hypertable-14.out
+++ b/tsl/test/expected/dist_hypertable-14.out
@@ -2141,13 +2141,13 @@ SELECT * FROM _timescaledb_catalog.hypertable;
 (3 rows)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func  | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+--------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                    |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          4 | _timescaledb_internal    | get_partition_hash |                 |                          |                         | 
 (5 rows)
 
 SELECT * FROM test.show_triggers('"Table\\Schema"."Param_Table"');
@@ -2176,13 +2176,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2210,13 +2210,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2244,13 +2244,13 @@ id|schema_name  |table_name     |associated_schema_name|associated_table_prefix|
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -2372,17 +2372,17 @@ SELECT * FROM dimented_table ORDER BY time;
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
@@ -2392,17 +2392,17 @@ SELECT * FROM attach_data_node(:'DATA_NODE_2', 'dimented_table');
 (1 row)
 
 SELECT * FROM _timescaledb_catalog.dimension;
- id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+-------------------------+------------------
-  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
-  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                         | 
-  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                         | 
- 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                         | 
+ id | hypertable_id |   column_name    |       column_type        | aligned | num_slices | partitioning_func_schema |   partitioning_func   | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+------------------+--------------------------+---------+------------+--------------------------+-----------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  2 |             1 | device           | integer                  | f       |          3 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  3 |             2 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  5 |             4 | time Col %#^#@$# | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  6 |             4 | __region         | text                     | f       |          2 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  7 |             5 | time             | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+  8 |             5 | column1          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_hash    |                 |                          |                         | 
+  9 |             5 | column2          | timestamp with time zone | t       |            |                          |                       |    604800000000 |                          |                         | 
+ 10 |             5 | column3          | integer                  | f       |          4 | _timescaledb_internal    | get_partition_for_key |                 |                          |                         | 
 (9 rows)
 
 -- ensure data node has new dimensions
@@ -2412,47 +2412,47 @@ $$);
 NOTICE:  [db_dist_hypertable_1]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 6|            4|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            4|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            4|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_2]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
- 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
- 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                       |                
-10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                       |                
-11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func    |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+---------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 6|            4|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 7|            4|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+ 8|            5|time            |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+ 9|            5|column1         |integer                 |f      |         4|_timescaledb_internal   |get_partition_hash   |               |                        |                       |                
+10|            5|column2         |timestamp with time zone|t      |          |                        |                     |   604800000000|                        |                       |                
+11|            5|column3         |integer                 |f      |         4|_timescaledb_internal   |get_partition_for_key|               |                        |                       |                
 (9 rows)
 
 
 NOTICE:  [db_dist_hypertable_3]: 
 SELECT * FROM _timescaledb_catalog.dimension
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
- 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
- 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                       |                
- 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                       |                
+id|hypertable_id|column_name     |column_type             |aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+----------------+------------------------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+ 1|            1|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 2|            1|device          |integer                 |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+ 3|            2|time            |timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 4|            3|time Col %#^#@$#|timestamp with time zone|t      |          |                        |                  |   604800000000|                        |                       |                
+ 5|            3|__region        |text                    |f      |         4|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
 (5 rows)
 
 
@@ -3425,9 +3425,9 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3435,9 +3435,9 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+20|           11|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3445,9 +3445,9 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+-----------------------+----------------
-14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func|interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+-----------------+---------------+------------------------+-----------------------+----------------
+14|            9|time       |bigint     |t      |          |                        |                 |        1000000|                        |                       |                
 (1 row)
 
 
@@ -3475,10 +3475,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3486,10 +3486,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3497,10 +3497,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                       |                
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         1|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |        1000000|                        |                       |                
 (2 rows)
 
 
@@ -3541,10 +3541,10 @@ NOTICE:  [db_dist_hypertable_1]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_1]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3552,10 +3552,10 @@ NOTICE:  [db_dist_hypertable_2]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_2]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+21|           11|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+20|           11|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 
@@ -3563,10 +3563,10 @@ NOTICE:  [db_dist_hypertable_3]:
 SELECT d.* FROM _timescaledb_catalog.hypertable h, _timescaledb_catalog.dimension d
 WHERE h.id = d.hypertable_id AND h.table_name = 'disttable'
 NOTICE:  [db_dist_hypertable_3]:
-id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|integer_now_func_schema|integer_now_func
---+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+-----------------------+----------------
-15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                       |                
-14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|public                 |dummy_now       
+id|hypertable_id|column_name|column_type|aligned|num_slices|partitioning_func_schema|partitioning_func |interval_length|compress_interval_length|integer_now_func_schema|integer_now_func
+--+-------------+-----------+-----------+-------+----------+------------------------+------------------+---------------+------------------------+-----------------------+----------------
+15|            9|device     |integer    |f      |         3|_timescaledb_internal   |get_partition_hash|               |                        |                       |                
+14|            9|time       |bigint     |t      |          |                        |                  |     2000000000|                        |public                 |dummy_now       
 (2 rows)
 
 

--- a/tsl/test/expected/tsl_tables.out
+++ b/tsl/test/expected/tsl_tables.out
@@ -189,10 +189,10 @@ select remove_retention_policy('test_table');
 -- Test set_integer_now_func and add_retention_policy with
 -- hypertables that have integer time dimension
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                         | 
-  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                         | 
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                          |                         | 
 (2 rows)
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
@@ -207,10 +207,10 @@ select set_integer_now_func('test_table_int', 'my_new_schema.dummy_now2');
 
 \c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
 select * from _timescaledb_catalog.dimension;
- id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | integer_now_func_schema | integer_now_func 
-----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+-------------------------+------------------
-  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                         | 
-  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 | my_new_schema           | dummy_now2
+ id | hypertable_id | column_name |       column_type        | aligned | num_slices | partitioning_func_schema | partitioning_func | interval_length | compress_interval_length | integer_now_func_schema | integer_now_func 
+----+---------------+-------------+--------------------------+---------+------------+--------------------------+-------------------+-----------------+--------------------------+-------------------------+------------------
+  1 |             1 | time        | timestamp with time zone | t       |            |                          |                   |    604800000000 |                          |                         | 
+  2 |             2 | time        | bigint                   | t       |            |                          |                   |               1 |                          | my_new_schema           | dummy_now2
 (2 rows)
 
 SELECT * FROM _timescaledb_config.bgw_job WHERE proc_name = 'policy_retention' ORDER BY id;

--- a/tsl/test/isolation/expected/compression_merge_race.out
+++ b/tsl/test/isolation/expected/compression_merge_race.out
@@ -1,0 +1,105 @@
+Parsed test spec with 3 sessions
+
+starting permutation: s3_count_chunks_pre_compression s3_lock_compression s1_compress_first_half_of_chunks s2_compress_second_half_of_chunks s3_unlock_compression s3_count_chunks_post_compression
+step s3_count_chunks_pre_compression: 
+    select count(*), 48 as expected from show_chunks('sensor_data');
+
+count|expected
+-----+--------
+   48|      48
+(1 row)
+
+step s3_lock_compression: 
+    SELECT debug_waitpoint_enable('compress_chunk_impl_start');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_compress_first_half_of_chunks: 
+   call compress_chunks_in_individual_transactions(
+     $$
+       select show_chunks('sensor_data') limit 24
+     $$
+   ); 
+ <waiting ...>
+step s2_compress_second_half_of_chunks: 
+   call compress_chunks_in_individual_transactions($$select show_chunks('sensor_data') i  offset 24$$); 
+ <waiting ...>
+step s3_unlock_compression: 
+    SELECT debug_waitpoint_release('compress_chunk_impl_start');
+ <waiting ...>
+step s1_compress_first_half_of_chunks: <... completed>
+step s2_compress_second_half_of_chunks: <... completed>
+step s3_unlock_compression: <... completed>
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s3_count_chunks_post_compression: 
+    select count(*), 24 as expected from show_chunks('sensor_data');
+
+count|expected
+-----+--------
+   24|      24
+(1 row)
+
+
+starting permutation: s3_count_chunks_pre_compression s3_lock_compression s1_compress_first_two_by_two s2_compress_second_two_by_two s3_unlock_compression s3_count_chunks_post_compression
+step s3_count_chunks_pre_compression: 
+    select count(*), 48 as expected from show_chunks('sensor_data');
+
+count|expected
+-----+--------
+   48|      48
+(1 row)
+
+step s3_lock_compression: 
+    SELECT debug_waitpoint_enable('compress_chunk_impl_start');
+
+debug_waitpoint_enable
+----------------------
+                      
+(1 row)
+
+step s1_compress_first_two_by_two: 
+   call compress_chunks_in_individual_transactions(
+     $$
+       select i.show_chunks 
+       from (
+         select row_number() over () as row_number, i as show_chunks 
+         from show_chunks('sensor_data') i
+       ) i where i.row_number%4 in (1,2) 
+     $$); 
+ <waiting ...>
+step s2_compress_second_two_by_two: 
+   call compress_chunks_in_individual_transactions(
+     $$
+       select i.show_chunks 
+       from (
+         select row_number() over () as row_number, i as show_chunks 
+         from show_chunks('sensor_data') i
+       ) i where i.row_number%4 in (3,0) 
+     $$); 
+ <waiting ...>
+step s3_unlock_compression: 
+    SELECT debug_waitpoint_release('compress_chunk_impl_start');
+ <waiting ...>
+step s1_compress_first_two_by_two: <... completed>
+step s2_compress_second_two_by_two: <... completed>
+step s3_unlock_compression: <... completed>
+debug_waitpoint_release
+-----------------------
+                       
+(1 row)
+
+step s3_count_chunks_post_compression: 
+    select count(*), 24 as expected from show_chunks('sensor_data');
+
+count|expected
+-----+--------
+   24|      24
+(1 row)
+

--- a/tsl/test/isolation/specs/CMakeLists.txt
+++ b/tsl/test/isolation/specs/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_TEMPLATES_MODULE_DEBUG
     cagg_drop_chunks.spec.in
     telemetry.spec.in
     compression_chunk_race.spec.in
+    compression_merge_race.spec.in
     decompression_chunk_and_parallel_query.in
     decompression_chunk_and_parallel_query_wo_idx.in)
 

--- a/tsl/test/isolation/specs/compression_merge_race.spec.in
+++ b/tsl/test/isolation/specs/compression_merge_race.spec.in
@@ -1,0 +1,124 @@
+# This file and its contents are licensed under the Timescale License.
+# Please see the included NOTICE for copyright information and
+# LICENSE-TIMESCALE for a copy of the license.
+
+###
+# Test the execution of two merge compression jobs in parallel
+###
+
+setup {
+   CREATE OR REPLACE FUNCTION debug_waitpoint_enable(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+     AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_enable';
+
+   CREATE OR REPLACE FUNCTION debug_waitpoint_release(TEXT) RETURNS VOID LANGUAGE C VOLATILE STRICT
+     AS '@TS_MODULE_PATHNAME@', 'ts_debug_point_release';
+
+
+   -- Compressing a lot of chunks from a single hypertable in a single transaction can
+   -- cause deadlocks due to locking the compressed hypertable when creating compressed chunks.
+   -- Hence we compress them in their individual transactions, similar how the compression
+   -- policies work.
+   CREATE OR REPLACE PROCEDURE compress_chunks_in_individual_transactions(query text)
+   LANGUAGE plpgsql
+   AS $$
+   DECLARE
+     chunk regclass;
+   BEGIN
+     FOR chunk in execute query
+     LOOP 
+       PERFORM public.compress_chunk(chunk); 
+       COMMIT;
+     END LOOP;
+   END;
+   $$;
+   
+   CREATE TABLE sensor_data (
+   time timestamptz not null,
+   sensor_id integer not null,
+   cpu double precision null,
+   temperature double precision null);
+
+   -- Create large chunks that take a long time to compress
+   SELECT FROM create_hypertable('sensor_data','time', chunk_time_interval => INTERVAL '1 hour', create_default_indexes => false);
+
+   INSERT INTO sensor_data
+   SELECT time + (INTERVAL '1 minute' * random()) AS time, sensor_id,
+   random() AS cpu,
+   random()* 100 AS temperature
+   FROM
+   generate_series('2022-01-01 00:00:00', '2022-01-02 23:59:59', INTERVAL '1 minute') AS g1(time),
+   generate_series(1, 50, 1) AS g2(sensor_id)
+   ORDER BY time;
+
+   
+   ALTER TABLE sensor_data SET (
+   timescaledb.compress, 
+   timescaledb.compress_segmentby = 'sensor_id, cpu',
+   timescaledb.compress_chunk_time_interval = '2 hours');
+}
+
+teardown {
+   DROP TABLE sensor_data;
+}
+
+session "s1"
+step "s1_compress_first_half_of_chunks" {
+   call compress_chunks_in_individual_transactions(
+     $$
+       select show_chunks('sensor_data') limit 24
+     $$
+   ); 
+}
+
+# Compress first two chunks, skip two and compress next two etc.
+step "s1_compress_first_two_by_two" {
+   call compress_chunks_in_individual_transactions(
+     $$
+       select i.show_chunks 
+       from (
+         select row_number() over () as row_number, i as show_chunks 
+         from show_chunks('sensor_data') i
+       ) i where i.row_number%4 in (1,2) 
+     $$); 
+}
+
+session "s2"
+step "s2_compress_second_half_of_chunks" {
+   call compress_chunks_in_individual_transactions($$select show_chunks('sensor_data') i  offset 24$$); 
+}
+
+# Compress second two chunks, skip two and compress next two etc.
+step "s2_compress_second_two_by_two" {
+   call compress_chunks_in_individual_transactions(
+     $$
+       select i.show_chunks 
+       from (
+         select row_number() over () as row_number, i as show_chunks 
+         from show_chunks('sensor_data') i
+       ) i where i.row_number%4 in (3,0) 
+     $$); 
+}
+
+session "s3"
+step "s3_lock_compression" {
+    SELECT debug_waitpoint_enable('compress_chunk_impl_start');
+}
+
+step "s3_unlock_compression" {
+    SELECT debug_waitpoint_release('compress_chunk_impl_start');
+}
+
+step "s3_count_chunks_pre_compression" {
+    select count(*), 48 as expected from show_chunks('sensor_data');
+}
+
+step "s3_count_chunks_post_compression" {
+    select count(*), 24 as expected from show_chunks('sensor_data');
+}
+
+
+# Check that we produce 24 chunks out of 48 chunks by merging two 1hour chunks
+# into 2 hour chunks from two different sessions. First session will run until
+# it hits an already compressed chunk.
+permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_half_of_chunks" "s2_compress_second_half_of_chunks" (s1_compress_first_half_of_chunks) "s3_unlock_compression" (s2_compress_second_half_of_chunks, s1_compress_first_half_of_chunks) "s3_count_chunks_post_compression"
+permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_two_by_two" "s2_compress_second_two_by_two" (s1_compress_first_two_by_two) "s3_unlock_compression" (s2_compress_second_two_by_two, s1_compress_first_two_by_two) "s3_count_chunks_post_compression"

--- a/tsl/test/sql/CMakeLists.txt
+++ b/tsl/test/sql/CMakeLists.txt
@@ -40,6 +40,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
     compression_ddl.sql
     compression_errors.sql
     compression_hypertable.sql
+    compression_merge.sql
     compression_segment_meta.sql
     compression.sql
     compress_table.sql

--- a/tsl/test/sql/compression_merge.sql
+++ b/tsl/test/sql/compression_merge.sql
@@ -1,0 +1,84 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\ir include/rand_generator.sql
+\c :TEST_DBNAME :ROLE_SUPERUSER
+\ir include/compression_utils.sql
+\c :TEST_DBNAME :ROLE_DEFAULT_PERM_USER
+
+CREATE TABLE test1 ("Time" timestamptz, i integer, value integer);
+SELECT table_name from create_hypertable('test1', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+
+-- This will generate 24 chunks
+INSERT INTO test1 SELECT t, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+
+-- Compression is set to merge those 24 chunks into 12 2 hour chunks
+ALTER TABLE test1 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+
+SELECT
+  $$
+  SELECT * FROM test1 ORDER BY "Time"
+  $$ AS "QUERY" \gset
+
+SELECT 'test1' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+\set TYPE timestamptz
+\set ORDER_BY_COL_NAME Time
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+
+DROP TABLE test1;
+
+CREATE TABLE test2 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test2', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+
+-- This will generate 24 1 hour chunks.
+INSERT INTO test2 SELECT t, gen_rand_minstd(), gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+
+-- Compression is set to merge those 24 chunks into 3 chunks, two 10 hour chunks and a single 4 hour chunk.
+ALTER TABLE test2 set (timescaledb.compress, timescaledb.compress_segmentby='i', timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='10 hours');
+
+SELECT
+  $$
+  SELECT * FROM test2 ORDER BY "Time"
+  $$ AS "QUERY" \gset
+
+SELECT 'test2' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+\set TYPE integer
+\set ORDER_BY_COL_NAME loc
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+
+DROP TABLE test2;
+
+CREATE TABLE test3 ("Time" timestamptz, i integer, loc integer, value integer);
+SELECT table_name from create_hypertable('test3', 'Time', chunk_time_interval=> INTERVAL '1 hour');
+SELECT table_name from  add_dimension('test3', 'i', chunk_time_interval=> 1);
+
+-- This will generate 25 1 hour chunks with a closed space dimension.
+INSERT INTO test3 SELECT t, 1, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 1:00'::TIMESTAMPTZ, '2018-03-02 12:59', '1 minute') t;
+INSERT INTO test3 SELECT t, 2, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 13:00'::TIMESTAMPTZ, '2018-03-03 0:59', '1 minute') t;
+INSERT INTO test3 SELECT t, 3, gen_rand_minstd(), gen_rand_minstd() FROM generate_series('2018-03-02 2:00'::TIMESTAMPTZ, '2018-03-02 2:01', '1 minute') t;
+
+-- Compression is set to merge those 25 chunks into 12 2 hour chunks and a single 1 hour chunks on a different space dimensions.
+ALTER TABLE test3 set (timescaledb.compress, timescaledb.compress_orderby='loc,"Time"', timescaledb.compress_chunk_time_interval='2 hours');
+
+SELECT
+  $$
+  SELECT * FROM test3 WHERE i = 1 ORDER BY "Time"
+  $$ AS "QUERY" \gset
+
+SELECT 'test3' AS "HYPERTABLE_NAME" \gset
+\ir include/compression_test_merge.sql
+
+\set TYPE integer
+\set ORDER_BY_COL_NAME loc
+\set SEGMENT_META_COL_MIN _ts_meta_min_1
+\set SEGMENT_META_COL_MAX _ts_meta_max_1
+\ir include/compression_test_hypertable_segment_meta.sql
+
+DROP TABLE test3;

--- a/tsl/test/sql/include/compression_test_merge.sql
+++ b/tsl/test/sql/include/compression_test_merge.sql
@@ -1,0 +1,43 @@
+-- This file and its contents are licensed under the Timescale License.
+-- Please see the included NOTICE for copyright information and
+-- LICENSE-TIMESCALE for a copy of the license.
+
+\set ECHO errors
+
+DROP TABLE IF EXISTS merge_result;
+
+CREATE TABLE merge_result AS :QUERY;
+
+SELECT count(compress_chunk(chunk)) as count_compressed
+FROM show_chunks(:'HYPERTABLE_NAME') chunk;
+
+with original AS (
+  SELECT row_number() OVER() row_number, * FROM merge_result
+),
+compressed AS (
+  SELECT row_number() OVER() row_number, * FROM (:QUERY) as q
+)
+SELECT 'Number of rows different between original and query on compressed data (expect 0)', count(*)
+FROM original
+FULL OUTER JOIN compressed ON (original.row_number = compressed.row_number)
+WHERE (original.*) IS DISTINCT FROM (compressed.*);
+
+SELECT count(decompress_chunk(chunk.schema_name|| '.' || chunk.table_name)) as count_decompressed
+FROM _timescaledb_catalog.chunk chunk
+INNER JOIN _timescaledb_catalog.hypertable hypertable ON (chunk.hypertable_id = hypertable.id)
+WHERE hypertable.table_name like :'HYPERTABLE_NAME' and chunk.compressed_chunk_id IS NOT NULL;
+
+
+--run data on data that's been compressed and decompressed, make sure it's the same.
+with original AS (
+  SELECT row_number() OVER() row_number, * FROM merge_result
+),
+uncompressed AS (
+  SELECT row_number() OVER() row_number, * FROM (:QUERY) as q
+)
+SELECT 'Number of rows different between original and data that has been compressed and then decompressed (expect 0)', count(*)
+FROM original
+FULL OUTER JOIN uncompressed ON (original.row_number = uncompressed.row_number)
+WHERE (original.*) IS DISTINCT FROM (uncompressed.*);
+
+\set ECHO all


### PR DESCRIPTION
This change introduces a new option to the compression procedure which decouples the uncompressed chunk interval from the compressed chunk interval. It does this by allowing multiple uncompressed chunks into one compressed chunk as part of the compression procedure. The main use-case is to allow much smaller uncompressed chunks than compressed ones. This has several advantages:
- Reduce the size of btrees on uncompressed data (thus allowing faster inserts because those indexes are memory-resident).
- Decrease disk-space usage for uncompressed data.
- Reduce number of chunks over historical data.

From a UX point of view, we simple add a compression with clause option `compress_chunk_time_interval`. The user should set that according to their needs for constraint exclusion over historical data. Ideally, it should be a multiple of the uncompressed chunk interval and so we throw a warning if it is not.