### PR TITLE
Insert into index during chunk compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ accidentally triggering the load of a previous DB version.**
 
 ## Unreleased
 
+**Features**
+* #5137 Insert into index during chunk compression
+
 **Bugfixes**
 * #4926 Fix corruption when inserting into compressed chunks
 

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -20,6 +20,7 @@
 #include <funcapi.h>
 #include <libpq/pqformat.h>
 #include <miscadmin.h>
+#include <nodes/execnodes.h>
 #include <nodes/pg_list.h>
 #include <storage/lmgr.h>
 #include <storage/predicate.h>
@@ -122,8 +123,11 @@ typedef struct RowCompressor
 	/* the table we're writing the compressed data to */
 	Relation compressed_table;
 	BulkInsertState bistate;
-	/* segment by index Oid if any */
-	Oid index_oid;
+	/* relation info necessary to update indexes on compressed table */
+	ResultRelInfo *resultRelInfo;
+	EState *estate;
+	/* segment by index index in the RelInfo if any */
+	int8 segmentby_index_index;
 
 	/* in theory we could have more input columns than outputted ones, so we
 	   store the number of inputs/compressors seperately*/
@@ -551,16 +555,6 @@ compress_chunk(Oid in_table, Oid out_table, const ColumnCompressionInfo **column
 	row_compressor_finish(&row_compressor);
 	truncate_relation(in_table);
 
-	/* Recreate all indexes on out rel, we already have an exclusive lock on it,
-	 * so the strong locks taken by reindex_relation shouldn't matter. */
-#if PG14_LT
-	int options = 0;
-#else
-	ReindexParams params = { 0 };
-	ReindexParams *options = &params;
-#endif
-	reindex_relation(out_table, 0, options);
-
 	table_close(out_rel, NoLock);
 	table_close(in_rel, NoLock);
 	cstat.rowcnt_pre_compression = row_compressor.rowcnt_pre_compression;
@@ -742,42 +736,37 @@ run_analyze_on_chunk(Oid chunk_relid)
 	ExecVacuum(NULL, &vs, true);
 }
 
-/* Find segment by index for setting the correct sequence number if
- * we are trying to roll up chunks while compressing
+/* Find segment by index index in relInfo for setting the correct sequence number if
+ * we are trying to roll up chunks while compressing.
+ *
+ * Returns -1 if none matching.
  */
-static Oid
-get_compressed_chunk_index(Relation compressed_chunk, int16 *uncompressed_col_to_compressed_col,
+static int8
+get_compressed_chunk_index(ResultRelInfo *resultRelInfo, int16 *uncompressed_col_to_compressed_col,
 						   PerColumn *per_column, int n_input_columns)
 {
-	ListCell *lc;
-	int i;
-
-	List *index_oids = RelationGetIndexList(compressed_chunk);
-
-	foreach (lc, index_oids)
+	for (int i = 0; i < resultRelInfo->ri_NumIndices; i++)
 	{
-		Oid index_oid = lfirst_oid(lc);
 		bool matches = true;
 		int num_segmentby_columns = 0;
-		Relation index_rel = index_open(index_oid, AccessShareLock);
-		IndexInfo *index_info = BuildIndexInfo(index_rel);
+		IndexInfo *index_info = resultRelInfo->ri_IndexRelationInfo[i];
 
-		for (i = 0; i < n_input_columns; i++)
+		for (int j = 0; j < n_input_columns; j++)
 		{
-			if (per_column[i].segmentby_column_index < 1)
+			if (per_column[j].segmentby_column_index < 1)
 				continue;
 
 			/* Last member of the index must be the sequence number column. */
-			if (per_column[i].segmentby_column_index >= index_rel->rd_att->natts)
+			if (per_column[j].segmentby_column_index >= index_info->ii_NumIndexAttrs)
 			{
 				matches = false;
 				break;
 			}
 
-			int index_att_offset = AttrNumberGetAttrOffset(per_column[i].segmentby_column_index);
+			int index_att_offset = AttrNumberGetAttrOffset(per_column[j].segmentby_column_index);
 
 			if (index_info->ii_IndexAttrNumbers[index_att_offset] !=
-				AttrOffsetGetAttrNumber(uncompressed_col_to_compressed_col[i]))
+				AttrOffsetGetAttrNumber(uncompressed_col_to_compressed_col[j]))
 			{
 				matches = false;
 				break;
@@ -789,27 +778,26 @@ get_compressed_chunk_index(Relation compressed_chunk, int16 *uncompressed_col_to
 		/* Check that we have the correct number of index attributes
 		 * and that the last one is the sequence number
 		 */
-		if (num_segmentby_columns != index_rel->rd_att->natts - 1 ||
-			namestrcmp((Name) &index_rel->rd_att->attrs[num_segmentby_columns].attname,
+		if (num_segmentby_columns != index_info->ii_NumIndexAttrs - 1 ||
+			namestrcmp((Name) &resultRelInfo->ri_IndexRelationDescs[i]
+						   ->rd_att->attrs[num_segmentby_columns]
+						   .attname,
 					   COMPRESSION_COLUMN_METADATA_SEQUENCE_NUM_NAME) != 0)
 			matches = false;
 
-		index_close(index_rel, AccessShareLock);
-
 		if (matches)
-			return index_oid;
+			return i;
 	}
 
-	return InvalidOid;
+	return -1;
 }
 
 static int32
-index_scan_sequence_number(Relation table_rel, Oid index_oid, ScanKeyData *scankey,
+index_scan_sequence_number(Relation table_rel, Relation index_rel, ScanKeyData *scankey,
 						   int num_scankeys)
 {
 	int32 result = 0;
 	bool is_null;
-	Relation index_rel = index_open(index_oid, AccessShareLock);
 
 	IndexScanDesc index_scan =
 		index_beginscan(table_rel, index_rel, GetTransactionSnapshot(), num_scankeys, 0);
@@ -828,7 +816,6 @@ index_scan_sequence_number(Relation table_rel, Oid index_oid, ScanKeyData *scank
 	}
 
 	index_endscan(index_scan);
-	index_close(index_rel, AccessShareLock);
 
 	return result;
 }
@@ -873,18 +860,11 @@ table_scan_sequence_number(Relation table_rel, int16 seq_num_column_num, ScanKey
  * SEQUENCE_NUM_GAP.
  */
 static int32
-get_sequence_number_for_current_group(Relation table_rel, Oid index_oid,
+get_sequence_number_for_current_group(Relation table_rel, Relation index_rel,
 									  int16 *uncompressed_col_to_compressed_col,
 									  PerColumn *per_column, int n_input_columns,
 									  int16 seq_num_column_num)
 {
-	/* No point scanning an empty relation. */
-	if (table_rel->rd_rel->relpages == 0)
-		return SEQUENCE_NUM_GAP;
-
-	/* If there is a suitable index, use index scan otherwise fallback to heap scan. */
-	bool is_index_scan = OidIsValid(index_oid);
-
 	int i, num_scankeys = 0;
 	int32 result = 0;
 
@@ -914,7 +894,7 @@ get_sequence_number_for_current_group(Relation table_rel, Oid index_oid,
 				continue;
 
 			PerColumn col = per_column[i];
-			int16 attno = is_index_scan ?
+			int16 attno = index_rel ?
 							  col.segmentby_column_index :
 							  AttrOffsetGetAttrNumber(uncompressed_col_to_compressed_col[i]);
 
@@ -943,12 +923,12 @@ get_sequence_number_for_current_group(Relation table_rel, Oid index_oid,
 		}
 	}
 
-	if (is_index_scan)
+	if (index_rel)
 	{
 		/* Index scan should always use at least one scan key to get the sequence number. */
 		Assert(num_scankeys > 0);
 
-		result = index_scan_sequence_number(table_rel, index_oid, scankey, num_scankeys);
+		result = index_scan_sequence_number(table_rel, index_rel, scankey, num_scankeys);
 	}
 	else
 	{
@@ -974,6 +954,9 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 {
 	TupleDesc out_desc = RelationGetDescr(compressed_table);
 	int col;
+	ResultRelInfo *resultRelInfo = makeNode(ResultRelInfo);
+	EState *estate = CreateExecutorState();
+	RangeTblEntry *rte = makeNode(RangeTblEntry);
 	Name count_metadata_name = DatumGetName(
 		DirectFunctionCall1(namein, CStringGetDatum(COMPRESSION_COLUMN_METADATA_COUNT_NAME)));
 	Name sequence_num_metadata_name = DatumGetName(
@@ -984,6 +967,31 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 	AttrNumber sequence_num_column_num =
 		get_attnum(compressed_table->rd_id, NameStr(*sequence_num_metadata_name));
 	Oid compressed_data_type_oid = ts_custom_type_cache_get(CUSTOM_TYPE_COMPRESSED_DATA)->type_oid;
+
+	/* Initialize result relation info and estate for index insertion */
+	rte->rtekind = RTE_RELATION;
+	rte->relid = compressed_table->rd_id;
+	rte->relkind = compressed_table->rd_rel->relkind;
+	rte->rellockmode = AccessShareLock;
+
+#if PG14_LT
+	InitResultRelInfo(resultRelInfo, compressed_table, 1, NULL, 0);
+#else
+	ExecInitRangeTable(estate, list_make1(rte));
+	ExecInitResultRelation(estate, resultRelInfo, 1);
+#endif
+
+	CheckValidResultRel(resultRelInfo, CMD_INSERT);
+	ExecOpenIndices(resultRelInfo, false);
+
+#if PG14_LT
+	estate->es_result_relations = resultRelInfo;
+	estate->es_num_result_relations = 1;
+	estate->es_result_relation_info = resultRelInfo;
+	estate->es_range_table = list_make1(rte);
+
+	ExecInitRangeTable(estate, estate->es_range_table);
+#endif
 
 	if (count_metadata_column_num == InvalidAttrNumber)
 		elog(ERROR,
@@ -1001,6 +1009,8 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 											 ALLOCSET_DEFAULT_SIZES),
 		.compressed_table = compressed_table,
 		.bistate = need_bistate ? GetBulkInsertState() : NULL,
+		.resultRelInfo = resultRelInfo,
+		.estate = estate,
 		.n_input_columns = uncompressed_tuple_desc->natts,
 		.per_column = palloc0(sizeof(PerColumn) * uncompressed_tuple_desc->natts),
 		.uncompressed_col_to_compressed_col =
@@ -1084,8 +1094,8 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 		}
 	}
 
-	row_compressor->index_oid =
-		get_compressed_chunk_index(compressed_table,
+	row_compressor->segmentby_index_index =
+		get_compressed_chunk_index(row_compressor->resultRelInfo,
 								   row_compressor->uncompressed_col_to_compressed_col,
 								   row_compressor->per_column,
 								   row_compressor->n_input_columns);
@@ -1184,7 +1194,11 @@ row_compressor_update_group(RowCompressor *row_compressor, TupleTableSlot *row)
 	 */
 	row_compressor->sequence_num =
 		get_sequence_number_for_current_group(row_compressor->compressed_table,
-											  row_compressor->index_oid,
+											  row_compressor->segmentby_index_index < 0 ?
+												  NULL :
+												  row_compressor->resultRelInfo
+													  ->ri_IndexRelationDescs
+														  [row_compressor->segmentby_index_index],
 											  row_compressor->uncompressed_col_to_compressed_col,
 											  row_compressor->per_column,
 											  row_compressor->n_input_columns,
@@ -1260,6 +1274,10 @@ row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool change
 {
 	int16 col;
 	HeapTuple compressed_tuple;
+	TupleTableSlot *myslot =
+		MakeTupleTableSlot(RelationGetDescr(row_compressor->resultRelInfo->ri_RelationDesc),
+						   &TTSOpsHeapTuple);
+	List *recheckIndexes = NIL;
 
 	for (col = 0; col < row_compressor->n_input_columns; col++)
 	{
@@ -1341,7 +1359,22 @@ row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool change
 				mycid,
 				0 /*=options*/,
 				row_compressor->bistate);
+	if (row_compressor->resultRelInfo->ri_NumIndices > 0)
+	{
+		myslot = ExecStoreHeapTuple(compressed_tuple, myslot, false);
+		recheckIndexes = ExecInsertIndexTuplesCompat(row_compressor->resultRelInfo,
+													 myslot,
+													 row_compressor->estate,
+													 false,
+													 false,
+													 NULL,
+													 NIL);
 
+		ExecClearTuple(myslot);
+		list_free(recheckIndexes);
+	}
+
+	ExecDropSingleTupleTableSlot(myslot);
 	heap_freetuple(compressed_tuple);
 
 	/* free the compressed values now that we're done with them (the old compressor is freed in
@@ -1396,6 +1429,14 @@ row_compressor_finish(RowCompressor *row_compressor)
 {
 	if (row_compressor->bistate)
 		FreeBulkInsertState(row_compressor->bistate);
+
+#if PG14_LT
+	ExecCloseIndices(row_compressor->resultRelInfo);
+	ExecCleanUpTriggerState(row_compressor->estate);
+#else
+	ExecCloseResultRelations(row_compressor->estate);
+	ExecCloseRangeTableRelations(row_compressor->estate);
+#endif
 }
 
 /******************

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -617,15 +617,15 @@ and ht.table_name like 'test_collation' ORDER BY ch1.id LIMIT 2;
 
 --segment bys are pushed down correctly
 EXPLAIN (costs off) SELECT * FROM test_collation WHERE device_id < 'a';
-                        QUERY PLAN                        
-----------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Append
    ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
-         ->  Seq Scan on compress_hyper_10_29_chunk
-               Filter: (device_id < 'a'::text)
+         ->  Index Scan using compress_hyper_10_29_chunk__compressed_hypertable_10_device_id_ on compress_hyper_10_29_chunk
+               Index Cond: (device_id < 'a'::text)
    ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
-         ->  Seq Scan on compress_hyper_10_30_chunk
-               Filter: (device_id < 'a'::text)
+         ->  Index Scan using compress_hyper_10_30_chunk__compressed_hypertable_10_device_id_ on compress_hyper_10_30_chunk
+               Index Cond: (device_id < 'a'::text)
    ->  Seq Scan on _hyper_9_21_chunk
          Filter: (device_id < 'a'::text)
    ->  Seq Scan on _hyper_9_22_chunk

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -594,6 +594,7 @@ SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
  _timescaledb_internal._hyper_29_19_chunk
 (1 row)
 
+ANALYZE test;
 --below query should pass after chunks are compressed
 SELECT 1 FROM test GROUP BY enum_col;
  ?column? 

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -659,3 +659,66 @@ SELECT count(*) FROM test8 WHERE series_id = 1;
    481
 (1 row)
 
+DROP TABLE test8;
+CREATE TABLE test9(time TIMESTAMPTZ NOT NULL, value DOUBLE PRECISION NOT NULL, series_id BIGINT NOT NULL);
+SELECT create_hypertable('test9', 'time', chunk_time_interval => INTERVAL '1 h');
+  create_hypertable  
+---------------------
+ (17,public,test9,t)
+(1 row)
+
+ALTER TABLE test9 set (timescaledb.compress,
+    timescaledb.compress_segmentby = 'series_id',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_chunk_time_interval = '1 day');
+INSERT INTO test9 (time, series_id, value) SELECT t, s, s%6 FROM generate_series(NOW(), NOW()+INTERVAL'4h', INTERVAL '30s') t CROSS JOIN generate_series(0, 100, 1) s;
+SELECT compress_chunk(c, true) FROM show_chunks('test9') c;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_320_chunk
+(5 rows)
+
+-- Verify index is being is correctly built and giving the same results as sequential scan.
+SET enable_indexscan TO OFF;
+SET enable_seqscan TO ON;
+SET enable_bitmapscan TO OFF;
+EXPLAIN (COSTS OFF) SELECT count(*) FROM test9 WHERE series_id IN (1, 50, 99);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (DecompressChunk) on _hyper_17_320_chunk
+         ->  Seq Scan on compress_hyper_18_325_chunk
+               Filter: (series_id = ANY ('{1,50,99}'::bigint[]))
+(4 rows)
+
+CREATE TABLE seq_data AS SELECT * FROM test9 WHERE series_id IN (1, 50, 99);
+SET enable_indexscan TO ON;
+SET enable_seqscan TO OFF;
+EXPLAIN (COSTS OFF) SELECT count(*) FROM test9 WHERE series_id IN (1, 50, 99);
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (DecompressChunk) on _hyper_17_320_chunk
+         ->  Index Scan using compress_hyper_18_325_chunk__compressed_hypertable_18_series_id on compress_hyper_18_325_chunk
+               Index Cond: (series_id = ANY ('{1,50,99}'::bigint[]))
+(4 rows)
+
+CREATE TABLE index_data AS SELECT * FROM test9 WHERE series_id IN (1, 50, 99);
+-- Make sure there are no distinct rows in both tables.
+SELECT count(*)
+FROM seq_data
+FULL OUTER JOIN index_data ON (seq_data.time = index_data.time AND seq_data.series_id = index_data.series_id)
+WHERE (seq_data.*) IS DISTINCT FROM (index_data.*);
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_indexscan;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+DROP TABLE test9;

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -196,36 +196,37 @@ SELECT compress_chunk(i) from show_chunks('pushdown_relabel') i;
 (1 row)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar';
-                     QUERY PLAN                     
-----------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
-         Filter: ((dev_vc)::text = 'varchar'::text)
+   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+         Index Cond: ((dev_vc)::text = 'varchar'::text)
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_c = 'char';
-                    QUERY PLAN                     
----------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
-         Filter: (dev_c = 'char'::bpchar)
+   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+         Index Cond: (dev_c = 'char'::bpchar)
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar' AND dev_c = 'char';
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
-         Filter: (((dev_vc)::text = 'varchar'::text) AND (dev_c = 'char'::bpchar))
+   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+         Index Cond: (((dev_vc)::text = 'varchar'::text) AND (dev_c = 'char'::bpchar))
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar'::char(10) AND dev_c = 'char'::varchar;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
-         Filter: (((dev_vc)::bpchar = 'varchar   '::character(10)) AND (dev_c = 'char'::bpchar))
-(3 rows)
+   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+         Index Cond: (dev_c = 'char'::bpchar)
+         Filter: ((dev_vc)::bpchar = 'varchar   '::character(10))
+(4 rows)
 
 -- test again with index scans
 SET enable_seqscan TO false;

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -6771,37 +6771,25 @@ ORDER BY c.id;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered WHERE device_id = 1 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
-(24 rows)
+               ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
+(12 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
@@ -6817,27 +6805,15 @@ ORDER BY c.id;
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
-(35 rows)
+                           ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
+(23 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -8041,37 +8041,25 @@ ORDER BY c.id;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered WHERE device_id = 1 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
-(24 rows)
+               ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
+(12 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
@@ -8087,27 +8075,15 @@ ORDER BY c.id;
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
-(35 rows)
+                           ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+(23 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -8041,37 +8041,25 @@ ORDER BY c.id;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered WHERE device_id = 1 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
-(24 rows)
+               ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
+(12 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
@@ -8087,27 +8075,15 @@ ORDER BY c.id;
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
-(35 rows)
+                           ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+(23 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -8043,37 +8043,25 @@ ORDER BY c.id;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered WHERE device_id = 1 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
-(24 rows)
+               ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
+(12 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
@@ -8089,27 +8077,15 @@ ORDER BY c.id;
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
-(35 rows)
+                           ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+(23 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -433,28 +433,40 @@ FROM (
         AND mt.device_id = nd.node
         AND mt.time < nd.stop_time) AS subq
 GROUP BY device_id;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: mt.device_id
-   ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Merge Append (actual rows=1541 loops=1)
-               Sort Key: mt.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
+   ->  Sort (actual rows=48 loops=1)
+         Sort Key: mt.device_id
+         Sort Method: quicksort 
+         ->  Nested Loop (actual rows=48 loops=1)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+               ->  Append (actual rows=48 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 96
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 192
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 1
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+(31 rows)
 
 :PREFIX
 SELECT nd.node,
@@ -514,34 +526,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt."time"
    Sort Method: quicksort 
-   ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt.device_id)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(25 rows)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;
@@ -554,30 +570,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt."time"
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (mt.device_id = nd.node)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 --enable all joins after the tests
 SET enable_mergejoin = TRUE;
@@ -774,8 +798,8 @@ ORDER BY 1,
     2,
     3,
     4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
    Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
    Sort Method: quicksort 
@@ -787,20 +811,15 @@ ORDER BY 1,
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -851,8 +870,8 @@ GROUP BY m.device_id,
 ORDER BY 1,
     2,
     3;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=42 loops=1)
    Sort Key: m.device_id, d.v0, (count(*))
    Sort Method: quicksort 
@@ -882,29 +901,30 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-               ->  Sort (actual rows=7317 loops=1)
-                     Sort Key: m."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
-                           Hypertable: metrics_ordered_idx
-                           Chunks excluded during startup: 0
-                           ->  Append (actual rows=1541 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
-(51 rows)
+               ->  Materialize (actual rows=7317 loops=1)
+                     ->  Sort (actual rows=1541 loops=1)
+                           Sort Key: m."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
+                                 Hypertable: metrics_ordered_idx
+                                 Chunks excluded during startup: 0
+                                 ->  Append (actual rows=1541 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
+(52 rows)
 
 --query with all chunks but 1 excluded at plan time --
 :PREFIX
@@ -916,21 +936,20 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=0 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               Rows Removed by Filter: 5
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=7)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (d.device_id = device_id) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               Rows Removed by Filter: 0
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=7)
+                     Index Cond: (device_id = d.device_id)
                      Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (never executed)
-               ->  Seq Scan on device_tbl d (never executed)
-(12 rows)
+(11 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -954,9 +973,9 @@ ORDER BY m.v0;
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
-                     Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id = 8)
+                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
 (13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
@@ -979,31 +998,26 @@ ORDER BY m.v0;
          Join Filter: ((m."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 7)
          ->  Hash (actual rows=0 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7
-(32 rows)
+(27 rows)
 
 SET timescaledb.enable_chunk_append TO TRUE;
 -- github bug 2917 with UNION ALL that references compressed ht

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -433,28 +433,40 @@ FROM (
         AND mt.device_id = nd.node
         AND mt.time < nd.stop_time) AS subq
 GROUP BY device_id;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: mt_1.device_id
-   ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time) AND (mt_1.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Merge Append (actual rows=1541 loops=1)
-               Sort Key: mt_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
+   ->  Sort (actual rows=48 loops=1)
+         Sort Key: mt_1.device_id
+         Sort Method: quicksort 
+         ->  Nested Loop (actual rows=48 loops=1)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+               ->  Append (actual rows=48 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 96
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 192
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 1
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+(31 rows)
 
 :PREFIX
 SELECT nd.node,
@@ -514,34 +526,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt_1.device_id)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(25 rows)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;
@@ -554,30 +570,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (mt_1.device_id = nd.node)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 --enable all joins after the tests
 SET enable_mergejoin = TRUE;
@@ -774,8 +798,8 @@ ORDER BY 1,
     2,
     3,
     4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
    Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
    Sort Method: quicksort 
@@ -787,20 +811,15 @@ ORDER BY 1,
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -852,8 +871,8 @@ GROUP BY m.device_id,
 ORDER BY 1,
     2,
     3;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=42 loops=1)
    Sort Key: m.device_id, d.v0, (count(*))
    Sort Method: quicksort 
@@ -884,29 +903,30 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-               ->  Sort (actual rows=7317 loops=1)
-                     Sort Key: m."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
-                           Hypertable: metrics_ordered_idx
-                           Chunks excluded during startup: 0
-                           ->  Append (actual rows=1541 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
-(52 rows)
+               ->  Materialize (actual rows=7317 loops=1)
+                     ->  Sort (actual rows=1541 loops=1)
+                           Sort Key: m."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
+                                 Hypertable: metrics_ordered_idx
+                                 Chunks excluded during startup: 0
+                                 ->  Append (actual rows=1541 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
+(53 rows)
 
 --query with all chunks but 1 excluded at plan time --
 :PREFIX
@@ -918,21 +938,20 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=0 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               Rows Removed by Filter: 5
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=7)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (d.device_id = device_id) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               Rows Removed by Filter: 0
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=7)
+                     Index Cond: (device_id = d.device_id)
                      Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (never executed)
-               ->  Seq Scan on device_tbl d (never executed)
-(12 rows)
+(11 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -956,9 +975,9 @@ ORDER BY m.v0;
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
-                     Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id = 8)
+                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
 (13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
@@ -981,31 +1000,26 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 7)
          ->  Hash (actual rows=0 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7
-(32 rows)
+(27 rows)
 
 SET timescaledb.enable_chunk_append TO TRUE;
 -- github bug 2917 with UNION ALL that references compressed ht

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -433,28 +433,40 @@ FROM (
         AND mt.device_id = nd.node
         AND mt.time < nd.stop_time) AS subq
 GROUP BY device_id;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: mt_1.device_id
-   ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time) AND (mt_1.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Merge Append (actual rows=1541 loops=1)
-               Sort Key: mt_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
+   ->  Sort (actual rows=48 loops=1)
+         Sort Key: mt_1.device_id
+         Sort Method: quicksort 
+         ->  Nested Loop (actual rows=48 loops=1)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+               ->  Append (actual rows=48 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 96
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 192
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 1
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+(31 rows)
 
 :PREFIX
 SELECT nd.node,
@@ -514,34 +526,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt_1.device_id)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(25 rows)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;
@@ -554,30 +570,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (mt_1.device_id = nd.node)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 --enable all joins after the tests
 SET enable_mergejoin = TRUE;
@@ -774,8 +798,8 @@ ORDER BY 1,
     2,
     3,
     4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
    Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
    Sort Method: quicksort 
@@ -787,20 +811,15 @@ ORDER BY 1,
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -852,8 +871,8 @@ GROUP BY m.device_id,
 ORDER BY 1,
     2,
     3;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=42 loops=1)
    Sort Key: m.device_id, d.v0, (count(*))
    Sort Method: quicksort 
@@ -884,29 +903,30 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-               ->  Sort (actual rows=7317 loops=1)
-                     Sort Key: m."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
-                           Hypertable: metrics_ordered_idx
-                           Chunks excluded during startup: 0
-                           ->  Append (actual rows=1541 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
-(52 rows)
+               ->  Materialize (actual rows=7317 loops=1)
+                     ->  Sort (actual rows=1541 loops=1)
+                           Sort Key: m."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
+                                 Hypertable: metrics_ordered_idx
+                                 Chunks excluded during startup: 0
+                                 ->  Append (actual rows=1541 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
+(53 rows)
 
 --query with all chunks but 1 excluded at plan time --
 :PREFIX
@@ -918,21 +938,20 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=0 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               Rows Removed by Filter: 5
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=7)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (d.device_id = device_id) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               Rows Removed by Filter: 0
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=7)
+                     Index Cond: (device_id = d.device_id)
                      Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (never executed)
-               ->  Seq Scan on device_tbl d (never executed)
-(12 rows)
+(11 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -956,9 +975,9 @@ ORDER BY m.v0;
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
-                     Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id = 8)
+                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
 (13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
@@ -981,31 +1000,26 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 7)
          ->  Hash (actual rows=0 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7
-(32 rows)
+(27 rows)
 
 SET timescaledb.enable_chunk_append TO TRUE;
 -- github bug 2917 with UNION ALL that references compressed ht

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -435,28 +435,40 @@ FROM (
         AND mt.device_id = nd.node
         AND mt.time < nd.stop_time) AS subq
 GROUP BY device_id;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: mt_1.device_id
-   ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time) AND (mt_1.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Merge Append (actual rows=1541 loops=1)
-               Sort Key: mt_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
+   ->  Sort (actual rows=48 loops=1)
+         Sort Key: mt_1.device_id
+         Sort Method: quicksort 
+         ->  Nested Loop (actual rows=48 loops=1)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+               ->  Append (actual rows=48 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 96
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 192
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 1
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+(31 rows)
 
 :PREFIX
 SELECT nd.node,
@@ -516,34 +528,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt_1.device_id)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(25 rows)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;
@@ -556,30 +572,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (mt_1.device_id = nd.node)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 --enable all joins after the tests
 SET enable_mergejoin = TRUE;
@@ -776,8 +800,8 @@ ORDER BY 1,
     2,
     3,
     4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
    Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
    Sort Method: quicksort 
@@ -789,20 +813,15 @@ ORDER BY 1,
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -854,8 +873,8 @@ GROUP BY m.device_id,
 ORDER BY 1,
     2,
     3;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=42 loops=1)
    Sort Key: m.device_id, d.v0, (count(*))
    Sort Method: quicksort 
@@ -886,29 +905,30 @@ ORDER BY 1,
                                  ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk d_5 (actual rows=5 loops=1)
                                        Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
                                        ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-               ->  Sort (actual rows=7317 loops=1)
-                     Sort Key: m."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
-                           Hypertable: metrics_ordered_idx
-                           Chunks excluded during startup: 0
-                           ->  Append (actual rows=1541 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
-                                 ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
-                                       Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
-                                       ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
-(52 rows)
+               ->  Materialize (actual rows=7317 loops=1)
+                     ->  Sort (actual rows=1541 loops=1)
+                           Sort Key: m."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (ConstraintAwareAppend) (actual rows=1541 loops=1)
+                                 Hypertable: metrics_ordered_idx
+                                 Chunks excluded during startup: 0
+                                 ->  Append (actual rows=1541 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=480 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_6_chunk compress_hyper_2_6_chunk_1 (actual rows=5 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=960 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_7_chunk compress_hyper_2_7_chunk_1 (actual rows=5 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=48 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_8_chunk compress_hyper_2_8_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=48 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_9_chunk compress_hyper_2_9_chunk_1 (actual rows=1 loops=1)
+                                       ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=5 loops=1)
+                                             Filter: ("time" > ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone)
+                                             ->  Seq Scan on compress_hyper_2_10_chunk compress_hyper_2_10_chunk_1 (actual rows=5 loops=1)
+(53 rows)
 
 --query with all chunks but 1 excluded at plan time --
 :PREFIX
@@ -920,21 +940,20 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                               QUERY PLAN                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=0 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               Rows Removed by Filter: 5
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=7)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (d.device_id = device_id) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               Rows Removed by Filter: 0
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=7)
+                     Index Cond: (device_id = d.device_id)
                      Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
-         ->  Hash (never executed)
-               ->  Seq Scan on device_tbl d (never executed)
-(12 rows)
+(11 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -958,9 +977,9 @@ ORDER BY m.v0;
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8))
-                     Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id = 8)
+                     Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone)
 (13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
@@ -983,31 +1002,26 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 7)
          ->  Hash (actual rows=0 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7
-(32 rows)
+(27 rows)
 
 SET timescaledb.enable_chunk_append TO TRUE;
 -- github bug 2917 with UNION ALL that references compressed ht

--- a/tsl/test/isolation/expected/compression_merge_race.out
+++ b/tsl/test/isolation/expected/compression_merge_race.out
@@ -103,3 +103,83 @@ count|expected
    24|      24
 (1 row)
 
+
+starting permutation: s1_compress_single_chunk s1_compress_all_chunks_single_transaction s3_select_on_compressed_chunk s3_wait_for_finish s1_compress_finish
+step s1_compress_single_chunk: 
+    select compress_chunk(c, true) from show_chunks('sensor_data') c limit 1;
+
+compress_chunk                        
+--------------------------------------
+_timescaledb_internal._hyper_X_X_chunk
+(1 row)
+
+step s1_compress_all_chunks_single_transaction: 
+    BEGIN;
+    select compress_chunk(c, true) from show_chunks('sensor_data') c;
+
+s1: NOTICE:  chunk "_hyper_X_X_chunk" is already compressed
+compress_chunk                         
+---------------------------------------
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk 
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+_timescaledb_internal._hyper_X_X_chunk
+(48 rows)
+
+step s3_select_on_compressed_chunk: 
+    SELECT count(*) FROM _timescaledb_internal.compress_hyper_X_X_chunk where sensor_id = 40 AND temperature IS NOT NULL;
+
+count
+-----
+    1
+(1 row)
+
+step s3_wait_for_finish: 
+
+step s1_compress_finish: 
+    COMMIT;
+

--- a/tsl/test/isolation/specs/compression_merge_race.spec.in
+++ b/tsl/test/isolation/specs/compression_merge_race.spec.in
@@ -54,11 +54,14 @@ setup {
    ALTER TABLE sensor_data SET (
    timescaledb.compress, 
    timescaledb.compress_segmentby = 'sensor_id',
+   timescaledb.compress_orderby = 'time',
    timescaledb.compress_chunk_time_interval = '2 hours');
 }
 
 teardown {
    DROP TABLE sensor_data;
+   ALTER SEQUENCE _timescaledb_catalog.hypertable_id_seq RESTART;
+   ALTER SEQUENCE _timescaledb_catalog.chunk_id_seq RESTART;
 }
 
 session "s1"
@@ -69,6 +72,20 @@ step "s1_compress_first_half_of_chunks" {
      $$
    ); 
 }
+
+step "s1_compress_all_chunks_single_transaction" {
+    BEGIN;
+    select compress_chunk(c, true) from show_chunks('sensor_data') c;
+}
+
+step "s1_compress_finish" {
+    COMMIT;
+}
+
+step "s1_compress_single_chunk" {
+    select compress_chunk(c, true) from show_chunks('sensor_data') c limit 1;
+}
+
 
 # Compress first two chunks, skip two and compress next two etc.
 step "s1_compress_first_two_by_two" {
@@ -116,9 +133,21 @@ step "s3_count_chunks_post_compression" {
     select count(*), 24 as expected from show_chunks('sensor_data');
 }
 
+step "s3_select_on_compressed_chunk" {
+    SELECT count(*) FROM _timescaledb_internal.compress_hyper_2_49_chunk where sensor_id = 40 AND temperature IS NOT NULL;
+}
+
+step "s3_wait_for_finish" {
+}
+
+
 
 # Check that we produce 24 chunks out of 48 chunks by merging two 1hour chunks
 # into 2 hour chunks from two different sessions. First session will run until
 # it hits an already compressed chunk.
 permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_half_of_chunks" "s2_compress_second_half_of_chunks" (s1_compress_first_half_of_chunks) "s3_unlock_compression" (s2_compress_second_half_of_chunks, s1_compress_first_half_of_chunks) "s3_count_chunks_post_compression"
 permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_two_by_two" "s2_compress_second_two_by_two" (s1_compress_first_two_by_two) "s3_unlock_compression" (s2_compress_second_two_by_two, s1_compress_first_two_by_two) "s3_count_chunks_post_compression"
+
+# Check that we can read existing compressed data during chunk compression when merging.
+# The query uses an index scan to verify we are not blocked on using it during compression.
+permutation "s1_compress_single_chunk" "s1_compress_all_chunks_single_transaction" "s3_select_on_compressed_chunk"  "s3_wait_for_finish" "s1_compress_finish"

--- a/tsl/test/shared/expected/constify_timestamptz_op_interval.out
+++ b/tsl/test/shared/expected/constify_timestamptz_op_interval.out
@@ -136,9 +136,10 @@ WHERE time < '2000-01-01'::timestamptz - '6h'::interval
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
    Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
-   ->  Seq Scan on compress_hyper_X_X_chunk
-         Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval)))
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk
+         Index Cond: (device_id = 1)
+         Filter: (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(5 rows)
 
 -- month/year intervals are not constified
 :PREFIX

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -2149,24 +2149,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2176,24 +2169,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2203,24 +2189,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2230,24 +2209,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2257,24 +2229,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 DEALLOCATE prep;
 -- executor startup exclusion with chunks excluded
@@ -2293,18 +2258,13 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2314,18 +2274,13 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2335,18 +2290,13 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2356,18 +2306,13 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2377,18 +2322,13 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 DEALLOCATE prep;
 -- runtime exclusion with LATERAL and 2 hypertables

--- a/tsl/test/shared/expected/ordered_append-12.out
+++ b/tsl/test/shared/expected/ordered_append-12.out
@@ -2226,21 +2226,12 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(9 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -2259,24 +2250,21 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
-(24 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(21 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -2317,18 +2305,15 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
-(16 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(13 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -2605,18 +2590,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -2679,18 +2661,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX
@@ -3036,22 +3015,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test RECORD in targetlist
 :PREFIX
@@ -3068,22 +3040,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test sort column not in targetlist
 :PREFIX
@@ -3129,51 +3094,24 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(48 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(21 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -3192,42 +3130,39 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 8
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
-(42 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(39 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -3268,27 +3203,24 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 8
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(25 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(22 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -3801,27 +3733,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -3908,27 +3837,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append-13.out
+++ b/tsl/test/shared/expected/ordered_append-13.out
@@ -2229,21 +2229,12 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(9 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -2262,24 +2253,21 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
-(24 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(21 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -2320,18 +2308,15 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
-(16 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(13 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -2608,18 +2593,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -2682,18 +2664,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX
@@ -3039,22 +3018,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test RECORD in targetlist
 :PREFIX
@@ -3071,22 +3043,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test sort column not in targetlist
 :PREFIX
@@ -3132,51 +3097,24 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(48 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(21 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -3195,42 +3133,39 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 8
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
-(42 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(39 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -3271,27 +3206,24 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 8
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(25 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(22 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -3804,27 +3736,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -3911,27 +3840,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -2229,21 +2229,12 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(9 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -2262,24 +2253,21 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
-(24 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(21 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -2320,18 +2308,15 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
-(16 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(13 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -2608,18 +2593,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -2682,18 +2664,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX
@@ -3039,22 +3018,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test RECORD in targetlist
 :PREFIX
@@ -3071,22 +3043,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test sort column not in targetlist
 :PREFIX
@@ -3132,51 +3097,24 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(48 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(21 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -3195,42 +3133,39 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 8
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
-(42 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(39 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -3271,27 +3206,24 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 8
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(25 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(22 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -3804,27 +3736,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -3911,27 +3840,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append-15.out
+++ b/tsl/test/shared/expected/ordered_append-15.out
@@ -2248,21 +2248,12 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(9 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -2281,24 +2272,21 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
-(24 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(21 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -2339,18 +2327,15 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
-(16 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(13 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -2627,18 +2612,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -2701,18 +2683,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX
@@ -3058,22 +3037,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test RECORD in targetlist
 :PREFIX
@@ -3091,22 +3063,15 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
                Order: metrics_space_compressed."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     ->  Sort (actual rows=1 loops=1)
-                           Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                           Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = 1)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 1)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     ->  Sort (never executed)
-                           Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                 Filter: (device_id = 1)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                           Index Cond: (device_id = 1)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     ->  Sort (never executed)
-                           Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                 Filter: (device_id = 1)
-(20 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                           Index Cond: (device_id = 1)
+(13 rows)
 
 -- test sort column not in targetlist
 :PREFIX
@@ -3152,51 +3117,24 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(48 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(21 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -3215,42 +3153,39 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 8
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
-(42 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(39 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -3291,27 +3226,24 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 8
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(25 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(22 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -3824,27 +3756,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -3931,27 +3860,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append_join-12.out
+++ b/tsl/test/shared/expected/ordered_append_join-12.out
@@ -2495,11 +2495,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1."time" = o2."time") AND (o1.device_id = o2.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1."time", o1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
@@ -2507,16 +2507,17 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_2 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=17990 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(22 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2."time", o2.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=17990 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -2753,22 +2754,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -3585,11 +3579,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1.device_id = o2.device_id) AND (o1."time" = o2."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1."time" = o2."time") AND (o1.device_id = o2.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1."time", o1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
@@ -3609,8 +3603,10 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_8 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Sort (actual rows=100 loops=1)
+                     Sort Key: o2."time", o2.device_id
+                     Sort Method: quicksort 
                      ->  Append (actual rows=68370 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=3598 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
@@ -3630,7 +3626,7 @@ QUERY PLAN
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=5038 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(46 rows)
+(48 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-13.out
+++ b/tsl/test/shared/expected/ordered_append_join-13.out
@@ -2495,11 +2495,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
@@ -2507,16 +2507,17 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(22 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -2753,22 +2754,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -3585,11 +3579,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
@@ -3609,8 +3603,10 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Sort (actual rows=100 loops=1)
+                     Sort Key: o2_1."time", o2_1.device_id
+                     Sort Method: quicksort 
                      ->  Append (actual rows=68370 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
@@ -3630,7 +3626,7 @@ QUERY PLAN
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(46 rows)
+(48 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-14.out
+++ b/tsl/test/shared/expected/ordered_append_join-14.out
@@ -2495,11 +2495,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
@@ -2507,16 +2507,17 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(22 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -2753,22 +2754,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -3585,11 +3579,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
@@ -3609,8 +3603,10 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Sort (actual rows=100 loops=1)
+                     Sort Key: o2_1."time", o2_1.device_id
+                     Sort Method: quicksort 
                      ->  Append (actual rows=68370 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
@@ -3630,7 +3626,7 @@ QUERY PLAN
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(46 rows)
+(48 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -2511,11 +2511,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=17990 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
@@ -2523,16 +2523,17 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_3 (actual rows=25190 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
-                     ->  Append (actual rows=68370 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
-                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
-(22 rows)
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o2_1."time", o2_1.device_id
+               Sort Method: quicksort 
+               ->  Append (actual rows=68370 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=17990 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=25190 loops=1)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=30 loops=1)
+(23 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable
@@ -2769,22 +2770,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -3605,11 +3599,11 @@ FROM :TEST_TABLE o1
   LIMIT 100;
 QUERY PLAN
  Limit (actual rows=100 loops=1)
-   ->  Sort (actual rows=100 loops=1)
-         Sort Key: o1_1."time"
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=68370 loops=1)
-               Hash Cond: ((o1_1.device_id = o2_1.device_id) AND (o1_1."time" = o2_1."time"))
+   ->  Merge Join (actual rows=100 loops=1)
+         Merge Cond: ((o1_1."time" = o2_1."time") AND (o1_1.device_id = o2_1.device_id))
+         ->  Sort (actual rows=100 loops=1)
+               Sort Key: o1_1."time", o1_1.device_id
+               Sort Method: quicksort 
                ->  Append (actual rows=68370 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_1 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
@@ -3629,8 +3623,10 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-               ->  Hash (actual rows=68370 loops=1)
-                     Buckets: 131072  Batches: 1 
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Sort (actual rows=100 loops=1)
+                     Sort Key: o2_1."time", o2_1.device_id
+                     Sort Method: quicksort 
                      ->  Append (actual rows=68370 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
@@ -3650,7 +3646,7 @@ QUERY PLAN
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
                            ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
                                  ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(46 rows)
+(48 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/transparent_decompress_chunk-12.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-12.out
@@ -49,10 +49,9 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 12
-(7 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(6 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
@@ -65,10 +64,9 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
-         Filter: (device_id < 0)
-         Rows Removed by Filter: 20
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Index Cond: (device_id < 0)
+(3 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
@@ -133,6 +131,7 @@ QUERY PLAN
 (4 rows)
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -144,6 +143,7 @@ QUERY PLAN
                      Filter: (device_id IS NOT NULL)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -163,10 +163,9 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
@@ -181,15 +180,20 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (device_id = v0)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (device_id = v0)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -201,6 +205,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -215,14 +220,18 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time"
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               Filter: (device_id = length("substring"(version(), 1, 3)))
-               Rows Removed by Filter: 14392
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time"
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1799 loops=2)
+                     Filter: (device_id = length("substring"(version(), 1, 3)))
+                     Rows Removed by Filter: 7196
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 -- test segment meta pushdown
 -- order by column and const
@@ -232,42 +241,48 @@ QUERY PLAN
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 2985
-         ->  Sort (actual rows=5 loops=1)
-               Sort Key: compress_hyper_X_X_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 15
-(10 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+               Rows Removed by Filter: 15
+(7 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=150 loops=1)
-               Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2840
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 15
-(10 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=75 loops=2)
+                     Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1420
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                           Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 8
+(14 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=155 loops=1)
-               Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2835
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 15
-(10 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=78 loops=2)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1418
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                           Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 8
+(14 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -307,31 +322,41 @@ QUERY PLAN
                      Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (9 rows)
 
+RESET parallel_leader_participation;
 --pushdowns between order by and segment by columns
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 < 1)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 < 1)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 < device_id)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 < device_id)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -343,30 +368,39 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v1 = device_id)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v1 = device_id)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 --pushdown between two order by column (not pushed down)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 = v1)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 = v1)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -384,6 +418,7 @@ QUERY PLAN
 (10 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -396,7 +431,9 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -408,26 +445,35 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test sort optimization interaction
 :PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(6 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(10 rows)
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(6 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(10 rows)
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
@@ -447,27 +493,21 @@ QUERY PLAN
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=5 loops=1)
-         Group Key: _hyper_X_X_chunk.device_id
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(7 rows)
+ GroupAggregate (actual rows=5 loops=1)
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(4 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  WindowAgg (actual rows=5 loops=1)
-         ->  HashAggregate (actual rows=5 loops=1)
-               Group Key: _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+ WindowAgg (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(5 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -656,6 +696,7 @@ QUERY PLAN
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -666,18 +707,20 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -691,26 +734,29 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
-                     ->  Hash Join (actual rows=17990 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                           ->  Hash (actual rows=3598 loops=1)
-                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
-                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
-                                             Index Cond: (device_id = 3)
-(19 rows)
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
+               ->  Hash Join (actual rows=17990 loops=1)
+                     Hash Cond: (m1."time" = m3."time")
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     ->  Hash (actual rows=3598 loops=1)
+                           Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
+                                       Index Cond: (device_id = 3)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(21 rows)
 
+RESET max_parallel_workers_per_gather;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -770,6 +816,8 @@ QUERY PLAN
 (20 rows)
 
 -- test OUTER JOIN
+SET parallel_leader_participation TO false;
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -780,19 +828,22 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+(14 rows)
 
+RESET max_parallel_workers_per_gather;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -816,13 +867,12 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Hash (actual rows=3598 loops=1)
-                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                     Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
                                  Index Cond: (device_id = 2)
 (15 rows)
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *
@@ -844,7 +894,7 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+                     Buckets: 65536  Batches: 8 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
 (12 rows)
@@ -872,7 +922,7 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+                     Buckets: 65536  Batches: 8 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
 (12 rows)

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -49,10 +49,9 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 12
-(7 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(6 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
@@ -65,10 +64,9 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
-         Filter: (device_id < 0)
-         Rows Removed by Filter: 20
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Index Cond: (device_id < 0)
+(3 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
@@ -133,6 +131,7 @@ QUERY PLAN
 (4 rows)
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -144,6 +143,7 @@ QUERY PLAN
                      Filter: (device_id IS NOT NULL)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -163,10 +163,9 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
@@ -181,15 +180,20 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (device_id = v0)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (device_id = v0)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -201,6 +205,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -215,14 +220,18 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time"
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               Filter: (device_id = length("substring"(version(), 1, 3)))
-               Rows Removed by Filter: 14392
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time"
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1799 loops=2)
+                     Filter: (device_id = length("substring"(version(), 1, 3)))
+                     Rows Removed by Filter: 7196
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 -- test segment meta pushdown
 -- order by column and const
@@ -232,42 +241,48 @@ QUERY PLAN
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 2985
-         ->  Sort (actual rows=5 loops=1)
-               Sort Key: compress_hyper_X_X_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 15
-(10 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+               Rows Removed by Filter: 15
+(7 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=150 loops=1)
-               Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2840
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 15
-(10 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=75 loops=2)
+                     Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1420
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                           Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 8
+(14 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=155 loops=1)
-               Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2835
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 15
-(10 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=78 loops=2)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1418
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                           Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 8
+(14 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -307,31 +322,41 @@ QUERY PLAN
                      Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (9 rows)
 
+RESET parallel_leader_participation;
 --pushdowns between order by and segment by columns
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 < 1)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 < 1)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 < device_id)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 < device_id)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -343,30 +368,39 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v1 = device_id)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v1 = device_id)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 --pushdown between two order by column (not pushed down)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 = v1)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 = v1)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -384,6 +418,7 @@ QUERY PLAN
 (10 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -396,7 +431,9 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -408,26 +445,35 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test sort optimization interaction
 :PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(6 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(10 rows)
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(6 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(10 rows)
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
@@ -447,29 +493,21 @@ QUERY PLAN
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=5 loops=1)
-         Group Key: _hyper_X_X_chunk.device_id
-         Batches: 1 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+ GroupAggregate (actual rows=5 loops=1)
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(4 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  WindowAgg (actual rows=5 loops=1)
-         ->  HashAggregate (actual rows=5 loops=1)
-               Group Key: _hyper_X_X_chunk.device_id
-               Batches: 1 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(9 rows)
+ WindowAgg (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(5 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -658,6 +696,7 @@ QUERY PLAN
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -668,18 +707,20 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -693,26 +734,29 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
-                     ->  Hash Join (actual rows=17990 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                           ->  Hash (actual rows=3598 loops=1)
-                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
-                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
-                                             Index Cond: (device_id = 3)
-(19 rows)
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
+               ->  Hash Join (actual rows=17990 loops=1)
+                     Hash Cond: (m1."time" = m3."time")
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     ->  Hash (actual rows=3598 loops=1)
+                           Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
+                                       Index Cond: (device_id = 3)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(21 rows)
 
+RESET max_parallel_workers_per_gather;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -772,6 +816,8 @@ QUERY PLAN
 (20 rows)
 
 -- test OUTER JOIN
+SET parallel_leader_participation TO false;
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -782,19 +828,22 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+(14 rows)
 
+RESET max_parallel_workers_per_gather;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -818,13 +867,12 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Hash (actual rows=3598 loops=1)
-                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                     Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
                                  Index Cond: (device_id = 2)
 (15 rows)
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *
@@ -849,12 +897,13 @@ QUERY PLAN
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Sort (actual rows=26 loops=1)
-                     Sort Key: m2."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(17 rows)
+               ->  Materialize (actual rows=26 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m2."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(18 rows)
 
 -- test self-join with sub-query
 :PREFIX
@@ -882,12 +931,13 @@ QUERY PLAN
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Sort (actual rows=26 loops=1)
-                     Sort Key: m2."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(17 rows)
+               ->  Materialize (actual rows=26 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m2."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(18 rows)
 
 RESET parallel_leader_participation;
 :PREFIX

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -49,10 +49,9 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 12
-(7 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(6 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
@@ -65,10 +64,9 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
-         Filter: (device_id < 0)
-         Rows Removed by Filter: 20
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Index Cond: (device_id < 0)
+(3 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
@@ -133,6 +131,7 @@ QUERY PLAN
 (4 rows)
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -144,6 +143,7 @@ QUERY PLAN
                      Filter: (device_id IS NOT NULL)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -163,10 +163,9 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
@@ -181,15 +180,20 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (device_id = v0)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (device_id = v0)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -201,6 +205,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -215,14 +220,18 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time"
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               Filter: (device_id = length("substring"(version(), 1, 3)))
-               Rows Removed by Filter: 14392
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time"
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1799 loops=2)
+                     Filter: (device_id = length("substring"(version(), 1, 3)))
+                     Rows Removed by Filter: 7196
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 -- test segment meta pushdown
 -- order by column and const
@@ -232,42 +241,48 @@ QUERY PLAN
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 2985
-         ->  Sort (actual rows=5 loops=1)
-               Sort Key: compress_hyper_X_X_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 15
-(10 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+               Rows Removed by Filter: 15
+(7 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=150 loops=1)
-               Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2840
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 15
-(10 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=75 loops=2)
+                     Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1420
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                           Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 8
+(14 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=155 loops=1)
-               Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2835
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 15
-(10 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=78 loops=2)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1418
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                           Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 8
+(14 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -307,31 +322,41 @@ QUERY PLAN
                      Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (9 rows)
 
+RESET parallel_leader_participation;
 --pushdowns between order by and segment by columns
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 < 1)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 < 1)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 < device_id)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 < device_id)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -343,30 +368,39 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v1 = device_id)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v1 = device_id)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 --pushdown between two order by column (not pushed down)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 = v1)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 = v1)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -384,6 +418,7 @@ QUERY PLAN
 (10 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -396,7 +431,9 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -408,26 +445,35 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test sort optimization interaction
 :PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(6 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(10 rows)
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(6 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(10 rows)
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
@@ -447,29 +493,21 @@ QUERY PLAN
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=5 loops=1)
-         Group Key: _hyper_X_X_chunk.device_id
-         Batches: 1 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+ GroupAggregate (actual rows=5 loops=1)
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(4 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  WindowAgg (actual rows=5 loops=1)
-         ->  HashAggregate (actual rows=5 loops=1)
-               Group Key: _hyper_X_X_chunk.device_id
-               Batches: 1 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(9 rows)
+ WindowAgg (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(5 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -658,6 +696,7 @@ QUERY PLAN
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -668,18 +707,20 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -693,26 +734,29 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
-                     ->  Hash Join (actual rows=17990 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                           ->  Hash (actual rows=3598 loops=1)
-                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
-                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
-                                             Index Cond: (device_id = 3)
-(19 rows)
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
+               ->  Hash Join (actual rows=17990 loops=1)
+                     Hash Cond: (m1."time" = m3."time")
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     ->  Hash (actual rows=3598 loops=1)
+                           Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
+                                       Index Cond: (device_id = 3)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(21 rows)
 
+RESET max_parallel_workers_per_gather;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -772,6 +816,8 @@ QUERY PLAN
 (20 rows)
 
 -- test OUTER JOIN
+SET parallel_leader_participation TO false;
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -782,19 +828,22 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+(14 rows)
 
+RESET max_parallel_workers_per_gather;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -818,13 +867,12 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Hash (actual rows=3598 loops=1)
-                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                     Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
                                  Index Cond: (device_id = 2)
 (15 rows)
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *
@@ -849,12 +897,13 @@ QUERY PLAN
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Sort (actual rows=26 loops=1)
-                     Sort Key: m2."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(17 rows)
+               ->  Materialize (actual rows=26 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m2."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(18 rows)
 
 -- test self-join with sub-query
 :PREFIX
@@ -882,12 +931,13 @@ QUERY PLAN
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Sort (actual rows=26 loops=1)
-                     Sort Key: m2."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(17 rows)
+               ->  Materialize (actual rows=26 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m2."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(18 rows)
 
 RESET parallel_leader_participation;
 :PREFIX

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -50,10 +50,9 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Result (actual rows=7196 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
@@ -66,10 +65,9 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
-         Filter: (device_id < 0)
-         Rows Removed by Filter: 20
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Index Cond: (device_id < 0)
+(3 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
@@ -135,6 +133,7 @@ QUERY PLAN
 (4 rows)
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -146,6 +145,7 @@ QUERY PLAN
                      Filter: (device_id IS NOT NULL)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -165,10 +165,9 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
@@ -183,15 +182,20 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (device_id = v0)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (device_id = v0)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -203,6 +207,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -217,14 +222,18 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time"
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               Filter: (device_id = length("substring"(version(), 1, 3)))
-               Rows Removed by Filter: 14392
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time"
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1799 loops=2)
+                     Filter: (device_id = length("substring"(version(), 1, 3)))
+                     Rows Removed by Filter: 7196
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 -- test segment meta pushdown
 -- order by column and const
@@ -234,42 +243,48 @@ QUERY PLAN
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 2985
-         ->  Sort (actual rows=5 loops=1)
-               Sort Key: compress_hyper_X_X_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 15
-(10 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+               Rows Removed by Filter: 15
+(7 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=150 loops=1)
-               Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2840
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 15
-(10 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=75 loops=2)
+                     Filter: ("time" < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1420
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                           Filter: (_ts_meta_min_1 < 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 8
+(14 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=155 loops=1)
-               Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-               Rows Removed by Filter: 2835
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
-                     Rows Removed by Filter: 15
-(10 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=78 loops=2)
+                     Filter: ("time" <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                     Rows Removed by Filter: 1418
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=2 loops=2)
+                           Filter: (_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
+                           Rows Removed by Filter: 8
+(14 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -309,31 +324,41 @@ QUERY PLAN
                      Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (9 rows)
 
+RESET parallel_leader_participation;
 --pushdowns between order by and segment by columns
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 < 1)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 < 1)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 < device_id)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 < device_id)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -345,30 +370,39 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v1 = device_id)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v1 = device_id)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 --pushdown between two order by column (not pushed down)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
-   ->  Sort (actual rows=0 loops=1)
-         Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
-         Sort Method: quicksort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-               Filter: (v0 = v1)
-               Rows Removed by Filter: 17990
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+   ->  Gather Merge (actual rows=0 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=0 loops=2)
+               Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
+               Sort Method: quicksort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=2)
+                     Filter: (v0 = v1)
+                     Rows Removed by Filter: 8995
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(12 rows)
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
@@ -386,6 +420,7 @@ QUERY PLAN
 (10 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -398,7 +433,9 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -410,26 +447,35 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test sort optimization interaction
 :PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(6 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time" DESC
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(10 rows)
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
-         Sort Method: top-N heapsort 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(6 rows)
+   ->  Gather Merge (actual rows=10 loops=1)
+         Workers Planned: 1
+         Workers Launched: 1
+         ->  Sort (actual rows=5 loops=2)
+               Sort Key: _hyper_X_X_chunk."time" DESC, _hyper_X_X_chunk.device_id
+               Sort Method: top-N heapsort 
+               Worker 0:  Sort Method: quicksort 
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=8995 loops=2)
+                     ->  Parallel Seq Scan on compress_hyper_X_X_chunk (actual rows=10 loops=2)
+(10 rows)
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
@@ -449,29 +495,21 @@ QUERY PLAN
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=5 loops=1)
-         Group Key: _hyper_X_X_chunk.device_id
-         Batches: 1 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+ GroupAggregate (actual rows=5 loops=1)
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(4 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  WindowAgg (actual rows=5 loops=1)
-         ->  HashAggregate (actual rows=5 loops=1)
-               Group Key: _hyper_X_X_chunk.device_id
-               Batches: 1 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(9 rows)
+ WindowAgg (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(5 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -660,6 +698,7 @@ QUERY PLAN
 
 DROP VIEW compressed_view;
 -- test INNER JOIN
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -670,18 +709,20 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+(14 rows)
 
 :PREFIX
 SELECT *
@@ -695,26 +736,29 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Join (actual rows=17990 loops=1)
-               Hash Cond: ((m2."time" = m1."time") AND (m2.device_id = m1.device_id))
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768 (originally 8192)  Batches: 1 (originally 1) 
-                     ->  Hash Join (actual rows=17990 loops=1)
-                           Hash Cond: (m1."time" = m3."time")
-                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
-                                 ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-                           ->  Hash (actual rows=3598 loops=1)
-                                 Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
-                                 ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
-                                       ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
-                                             Index Cond: (device_id = 3)
-(19 rows)
+   ->  Merge Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
+               ->  Hash Join (actual rows=17990 loops=1)
+                     Hash Cond: (m1."time" = m3."time")
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+                     ->  Hash (actual rows=3598 loops=1)
+                           Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2 (actual rows=4 loops=1)
+                                       Index Cond: (device_id = 3)
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(21 rows)
 
+RESET max_parallel_workers_per_gather;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -774,6 +818,8 @@ QUERY PLAN
 (20 rows)
 
 -- test OUTER JOIN
+SET parallel_leader_participation TO false;
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -784,19 +830,22 @@ ORDER BY m1.time,
 LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
-   ->  Sort (actual rows=10 loops=1)
-         Sort Key: m1."time", m1.device_id
-         Sort Method: top-N heapsort 
-         ->  Hash Left Join (actual rows=17990 loops=1)
-               Hash Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+   ->  Merge Left Join (actual rows=10 loops=1)
+         Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
+         ->  Sort (actual rows=10 loops=1)
+               Sort Key: m1."time", m1.device_id
+               Sort Method: quicksort 
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Hash (actual rows=17990 loops=1)
-                     Buckets: 32768  Batches: 1 
+         ->  Materialize (actual rows=10 loops=1)
+               ->  Sort (actual rows=10 loops=1)
+                     Sort Key: m2."time", m2.device_id
+                     Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(12 rows)
+(14 rows)
 
+RESET max_parallel_workers_per_gather;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -820,13 +869,12 @@ QUERY PLAN
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                      ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
                ->  Hash (actual rows=3598 loops=1)
-                     Buckets: 4096 (originally 1024)  Batches: 1 (originally 1) 
+                     Buckets: 4096 (originally 2048)  Batches: 1 (originally 1) 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=3598 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
                                  Index Cond: (device_id = 2)
 (15 rows)
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *
@@ -851,12 +899,13 @@ QUERY PLAN
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Sort (actual rows=26 loops=1)
-                     Sort Key: m2."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(17 rows)
+               ->  Materialize (actual rows=26 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m2."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(18 rows)
 
 -- test self-join with sub-query
 :PREFIX
@@ -884,12 +933,13 @@ QUERY PLAN
                      Sort Method: quicksort 
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1 (actual rows=17990 loops=1)
                            ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-               ->  Sort (actual rows=26 loops=1)
-                     Sort Key: m2."time"
-                     Sort Method: quicksort 
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
-(17 rows)
+               ->  Materialize (actual rows=26 loops=1)
+                     ->  Sort (actual rows=6 loops=1)
+                           Sort Key: m2."time"
+                           Sort Method: quicksort 
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2 (actual rows=17990 loops=1)
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=20 loops=1)
+(18 rows)
 
 RESET parallel_leader_participation;
 :PREFIX

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -56,7 +56,9 @@ ORDER BY time, device_id;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 
@@ -68,7 +70,9 @@ ORDER BY time, device_id;
 
 --test var op var
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
@@ -84,14 +88,18 @@ ORDER BY time, device_id;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 --pushdowns between order by and segment by columns
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v1 = device_id ORDER BY time, device_id LIMIT 10;
 
 --pushdown between two order by column (not pushed down)
@@ -101,10 +109,14 @@ ORDER BY time, device_id;
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 -- test sort optimization interaction
 :PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
@@ -187,6 +199,7 @@ CREATE OR REPLACE VIEW compressed_view AS SELECT time, device_id, v1, v2 FROM :T
 DROP VIEW compressed_view;
 
 -- test INNER JOIN
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -206,6 +219,7 @@ FROM :TEST_TABLE m1
     ORDER BY m1.time,
         m1.device_id
     LIMIT 10;
+RESET max_parallel_workers_per_gather;
 
 :PREFIX
 SELECT *
@@ -232,6 +246,8 @@ FROM metrics m1
     LIMIT 100;
 
 -- test OUTER JOIN
+SET parallel_leader_participation TO false;
+SET max_parallel_workers_per_gather = 0;
 :PREFIX
 SELECT *
 FROM :TEST_TABLE m1
@@ -240,6 +256,7 @@ FROM :TEST_TABLE m1
 ORDER BY m1.time,
     m1.device_id
 LIMIT 10;
+RESET max_parallel_workers_per_gather;
 
 :PREFIX
 SELECT *
@@ -253,7 +270,6 @@ ORDER BY m1.time,
     m2.device_id
 LIMIT 100;
 
-SET parallel_leader_participation TO false;
 -- test implicit self-join
 :PREFIX
 SELECT *

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -344,6 +344,7 @@ EXPLAIN SELECT DISTINCT 1 FROM test;
 
 --compress chunks
 SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
+ANALYZE test;
 
 --below query should pass after chunks are compressed
 SELECT 1 FROM test GROUP BY enum_col;


### PR DESCRIPTION
If there is an index on the compressed chunk, insert into it while inserting the heap data rather than reindexing the relation at the end. This reduces the amount of locking on the compressed chunk index which created issues when merging chunks and should help with the future updates of compressed data.