### PR TITLE
Insert into indexes during chunk compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ accidentally triggering the load of a previous DB version.**
 * #5547 Skip Ordered Append when only 1 child node is present
 * #5510 Propagate vacuum/analyze to compressed chunks
 * #5584 Reduce decompression during constraint checking
+* #5137 Insert into index during chunk compression
 
 **Bugfixes**
 * #5396 Fix SEGMENTBY columns predicates to be pushed down

--- a/test/sql/updates/post.compression.sql
+++ b/test/sql/updates/post.compression.sql
@@ -2,6 +2,7 @@
 -- Please see the included NOTICE for copyright information and
 -- LICENSE-APACHE for a copy of the license.
 
+ANALYZE compress;
 SELECT * FROM compress ORDER BY time DESC, small_cardinality;
 
 INSERT INTO compress
@@ -17,6 +18,7 @@ WHERE
   hypertable.table_name = 'compress'
   AND chunk.compressed_chunk_id IS NULL;
 
+ANALYZE compress;
 SELECT * FROM compress ORDER BY time DESC, small_cardinality;
 
 \x on

--- a/tsl/src/compression/api.c
+++ b/tsl/src/compression/api.c
@@ -1065,7 +1065,7 @@ tsl_get_compressed_chunk_index_for_recompression(PG_FUNCTION_ARGS)
 						in_column_offsets,
 						compressed_rel_tupdesc->natts,
 						true /*need_bistate*/,
-						true /*segmentwise_recompress*/);
+						true /*reset_sequence*/);
 
 	/*
 	 * Keep the ExclusiveLock on the compressed chunk. This lock will be requested
@@ -1363,7 +1363,7 @@ tsl_recompress_chunk_segmentwise(PG_FUNCTION_ARGS)
 						in_column_offsets,
 						compressed_rel_tupdesc->natts,
 						true /*need_bistate*/,
-						true /*segmentwise_recompress*/);
+						true /*reset_sequence*/);
 
 	/* create an array of the segmentby column offsets in the compressed chunk */
 	int16 *segmentby_column_offsets_compressed =

--- a/tsl/src/compression/compression.c
+++ b/tsl/src/compression/compression.c
@@ -21,6 +21,7 @@
 #include <funcapi.h>
 #include <libpq/pqformat.h>
 #include <miscadmin.h>
+#include <nodes/execnodes.h>
 #include <nodes/pg_list.h>
 #include <nodes/print.h>
 #include <storage/lmgr.h>
@@ -337,7 +338,7 @@ compress_chunk(Oid in_table, Oid out_table, const ColumnCompressionInfo **column
 						in_column_offsets,
 						out_desc->natts,
 						true /*need_bistate*/,
-						false /*segmentwise_recompress*/);
+						false /*reset_sequence*/);
 
 	if (matched_index_rel != NULL)
 	{
@@ -380,16 +381,6 @@ compress_chunk(Oid in_table, Oid out_table, const ColumnCompressionInfo **column
 
 	row_compressor_finish(&row_compressor);
 	truncate_relation(in_table);
-
-	/* Recreate all indexes on out rel, we already have an exclusive lock on it,
-	 * so the strong locks taken by reindex_relation shouldn't matter. */
-#if PG14_LT
-	int options = 0;
-#else
-	ReindexParams params = { 0 };
-	ReindexParams *options = &params;
-#endif
-	reindex_relation(out_table, 0, options);
 
 	table_close(out_rel, NoLock);
 	table_close(in_rel, NoLock);
@@ -571,38 +562,31 @@ run_analyze_on_chunk(Oid chunk_relid)
  * we are trying to roll up chunks while compressing
  */
 static Oid
-get_compressed_chunk_index(Relation compressed_chunk, int16 *uncompressed_col_to_compressed_col,
+get_compressed_chunk_index(ResultRelInfo *resultRelInfo, int16 *uncompressed_col_to_compressed_col,
 						   PerColumn *per_column, int n_input_columns)
 {
-	ListCell *lc;
-	int i;
-
-	List *index_oids = RelationGetIndexList(compressed_chunk);
-
-	foreach (lc, index_oids)
+	for (int i = 0; i < resultRelInfo->ri_NumIndices; i++)
 	{
-		Oid index_oid = lfirst_oid(lc);
 		bool matches = true;
 		int num_segmentby_columns = 0;
-		Relation index_rel = index_open(index_oid, AccessShareLock);
-		IndexInfo *index_info = BuildIndexInfo(index_rel);
+		IndexInfo *index_info = resultRelInfo->ri_IndexRelationInfo[i];
 
-		for (i = 0; i < n_input_columns; i++)
+		for (int j = 0; j < n_input_columns; j++)
 		{
-			if (per_column[i].segmentby_column_index < 1)
+			if (per_column[j].segmentby_column_index < 1)
 				continue;
 
 			/* Last member of the index must be the sequence number column. */
-			if (per_column[i].segmentby_column_index >= index_rel->rd_att->natts)
+			if (per_column[j].segmentby_column_index >= index_info->ii_NumIndexAttrs)
 			{
 				matches = false;
 				break;
 			}
 
-			int index_att_offset = AttrNumberGetAttrOffset(per_column[i].segmentby_column_index);
+			int index_att_offset = AttrNumberGetAttrOffset(per_column[j].segmentby_column_index);
 
 			if (index_info->ii_IndexAttrNumbers[index_att_offset] !=
-				AttrOffsetGetAttrNumber(uncompressed_col_to_compressed_col[i]))
+				AttrOffsetGetAttrNumber(uncompressed_col_to_compressed_col[j]))
 			{
 				matches = false;
 				break;
@@ -614,15 +598,15 @@ get_compressed_chunk_index(Relation compressed_chunk, int16 *uncompressed_col_to
 		/* Check that we have the correct number of index attributes
 		 * and that the last one is the sequence number
 		 */
-		if (num_segmentby_columns != index_rel->rd_att->natts - 1 ||
-			namestrcmp((Name) &index_rel->rd_att->attrs[num_segmentby_columns].attname,
+		if (num_segmentby_columns != index_info->ii_NumIndexAttrs - 1 ||
+			namestrcmp((Name) &resultRelInfo->ri_IndexRelationDescs[i]
+						   ->rd_att->attrs[num_segmentby_columns]
+						   .attname,
 					   COMPRESSION_COLUMN_METADATA_SEQUENCE_NUM_NAME) != 0)
 			matches = false;
 
-		index_close(index_rel, AccessShareLock);
-
 		if (matches)
-			return index_oid;
+			return resultRelInfo->ri_IndexRelationDescs[i]->rd_id;
 	}
 
 	return InvalidOid;
@@ -703,10 +687,6 @@ get_sequence_number_for_current_group(Relation table_rel, Oid index_oid,
 									  PerColumn *per_column, int n_input_columns,
 									  int16 seq_num_column_num)
 {
-	/* No point scanning an empty relation. */
-	if (table_rel->rd_rel->relpages == 0)
-		return SEQUENCE_NUM_GAP;
-
 	/* If there is a suitable index, use index scan otherwise fallback to heap scan. */
 	bool is_index_scan = OidIsValid(index_oid);
 
@@ -795,8 +775,7 @@ void
 row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_desc,
 					Relation compressed_table, int num_compression_infos,
 					const ColumnCompressionInfo **column_compression_info, int16 *in_column_offsets,
-					int16 num_columns_in_compressed_table, bool need_bistate,
-					bool segmentwise_recompress)
+					int16 num_columns_in_compressed_table, bool need_bistate, bool reset_sequence)
 {
 	TupleDesc out_desc = RelationGetDescr(compressed_table);
 	int col;
@@ -827,6 +806,7 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 											 ALLOCSET_DEFAULT_SIZES),
 		.compressed_table = compressed_table,
 		.bistate = need_bistate ? GetBulkInsertState() : NULL,
+		.resultRelInfo = ts_catalog_open_indexes(compressed_table),
 		.n_input_columns = uncompressed_tuple_desc->natts,
 		.per_column = palloc0(sizeof(PerColumn) * uncompressed_tuple_desc->natts),
 		.uncompressed_col_to_compressed_col =
@@ -840,7 +820,7 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 		.rowcnt_pre_compression = 0,
 		.num_compressed_rows = 0,
 		.sequence_num = SEQUENCE_NUM_GAP,
-		.segmentwise_recompress = segmentwise_recompress,
+		.reset_sequence = reset_sequence,
 		.first_iteration = true,
 	};
 
@@ -913,7 +893,7 @@ row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompressed_tuple_
 	}
 
 	row_compressor->index_oid =
-		get_compressed_chunk_index(compressed_table,
+		get_compressed_chunk_index(row_compressor->resultRelInfo,
 								   row_compressor->uncompressed_col_to_compressed_col,
 								   row_compressor->per_column,
 								   row_compressor->n_input_columns);
@@ -998,8 +978,8 @@ row_compressor_update_group(RowCompressor *row_compressor, TupleTableSlot *row)
 
 		Assert(column->compressor == NULL);
 
-		/* Performance Improvment: We should just use array access here; everything is guaranteed to
-		   be fetched */
+		/* Performance Improvement: We should just use array access here; everything is guaranteed
+		   to be fetched */
 		val = slot_getattr(row, AttrOffsetGetAttrNumber(col), &is_null);
 		segment_info_update(column->segment_info, val, is_null);
 	}
@@ -1012,7 +992,9 @@ row_compressor_update_group(RowCompressor *row_compressor, TupleTableSlot *row)
 	 * many segmentby columns.
 	 *
 	 */
-	if (!row_compressor->segmentwise_recompress)
+	if (row_compressor->reset_sequence)
+		row_compressor->sequence_num = SEQUENCE_NUM_GAP; /* Start sequence from beginning */
+	else
 		row_compressor->sequence_num =
 			get_sequence_number_for_current_group(row_compressor->compressed_table,
 												  row_compressor->index_oid,
@@ -1023,8 +1005,6 @@ row_compressor_update_group(RowCompressor *row_compressor, TupleTableSlot *row)
 												  AttrOffsetGetAttrNumber(
 													  row_compressor
 														  ->sequence_num_metadata_column_offset));
-	else
-		row_compressor->sequence_num = SEQUENCE_NUM_GAP;
 }
 
 static bool
@@ -1175,6 +1155,10 @@ row_compressor_flush(RowCompressor *row_compressor, CommandId mycid, bool change
 				mycid,
 				0 /*=options*/,
 				row_compressor->bistate);
+	if (row_compressor->resultRelInfo->ri_NumIndices > 0)
+	{
+		ts_catalog_index_insert(row_compressor->resultRelInfo, compressed_tuple);
+	}
 
 	heap_freetuple(compressed_tuple);
 
@@ -1230,6 +1214,7 @@ row_compressor_finish(RowCompressor *row_compressor)
 {
 	if (row_compressor->bistate)
 		FreeBulkInsertState(row_compressor->bistate);
+	ts_catalog_close_indexes(row_compressor->resultRelInfo);
 }
 
 /******************

--- a/tsl/src/compression/compression.h
+++ b/tsl/src/compression/compression.h
@@ -220,6 +220,10 @@ typedef struct RowCompressor
 	BulkInsertState bistate;
 	/* segment by index Oid if any */
 	Oid index_oid;
+	/* relation info necessary to update indexes on compressed table */
+	ResultRelInfo *resultRelInfo;
+	/* segment by index index in the RelInfo if any */
+	int8 segmentby_index_index;
 
 	/* in theory we could have more input columns than outputted ones, so we
 	   store the number of inputs/compressors separately */
@@ -246,8 +250,8 @@ typedef struct RowCompressor
 	bool *compressed_is_null;
 	int64 rowcnt_pre_compression;
 	int64 num_compressed_rows;
-	/* if recompressing segmentwise, we must know this so we can reset the sequence number */
-	bool segmentwise_recompress;
+	/* if recompressing segmentwise, we use this info to reset the sequence number */
+	bool reset_sequence;
 	/* flag for checking if we are working on the first tuple */
 	bool first_iteration;
 } RowCompressor;
@@ -335,7 +339,7 @@ extern void row_compressor_init(RowCompressor *row_compressor, TupleDesc uncompr
 								Relation compressed_table, int num_compression_infos,
 								const ColumnCompressionInfo **column_compression_info,
 								int16 *column_offsets, int16 num_columns_in_compressed_table,
-								bool need_bistate, bool segmentwise_recompress);
+								bool need_bistate, bool reset_sequence);
 extern void row_compressor_finish(RowCompressor *row_compressor);
 extern void populate_per_compressed_columns_from_data(PerCompressedColumn *per_compressed_cols,
 													  int16 num_cols, Datum *compressed_datums,

--- a/tsl/test/expected/compression.out
+++ b/tsl/test/expected/compression.out
@@ -626,15 +626,15 @@ and ht.table_name like 'test_collation' ORDER BY ch1.id LIMIT 2;
 
 --segment bys are pushed down correctly
 EXPLAIN (costs off) SELECT * FROM test_collation WHERE device_id < 'a';
-                        QUERY PLAN                        
-----------------------------------------------------------
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
  Append
    ->  Custom Scan (DecompressChunk) on _hyper_9_19_chunk
-         ->  Seq Scan on compress_hyper_10_29_chunk
-               Filter: (device_id < 'a'::text)
+         ->  Index Scan using compress_hyper_10_29_chunk__compressed_hypertable_10_device_id_ on compress_hyper_10_29_chunk
+               Index Cond: (device_id < 'a'::text)
    ->  Custom Scan (DecompressChunk) on _hyper_9_20_chunk
-         ->  Seq Scan on compress_hyper_10_30_chunk
-               Filter: (device_id < 'a'::text)
+         ->  Index Scan using compress_hyper_10_30_chunk__compressed_hypertable_10_device_id_ on compress_hyper_10_30_chunk
+               Index Cond: (device_id < 'a'::text)
    ->  Seq Scan on _hyper_9_21_chunk
          Filter: (device_id < 'a'::text)
    ->  Seq Scan on _hyper_9_22_chunk

--- a/tsl/test/expected/compression_errors.out
+++ b/tsl/test/expected/compression_errors.out
@@ -593,6 +593,7 @@ SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
  _timescaledb_internal._hyper_31_19_chunk
 (1 row)
 
+ANALYZE test;
 --below query should pass after chunks are compressed
 SELECT 1 FROM test GROUP BY enum_col;
  ?column? 

--- a/tsl/test/expected/compression_merge.out
+++ b/tsl/test/expected/compression_merge.out
@@ -659,3 +659,66 @@ SELECT count(*) FROM test8 WHERE series_id = 1;
    481
 (1 row)
 
+DROP TABLE test8;
+CREATE TABLE test9(time TIMESTAMPTZ NOT NULL, value DOUBLE PRECISION NOT NULL, series_id BIGINT NOT NULL);
+SELECT create_hypertable('test9', 'time', chunk_time_interval => INTERVAL '1 h');
+  create_hypertable  
+---------------------
+ (17,public,test9,t)
+(1 row)
+
+ALTER TABLE test9 set (timescaledb.compress,
+    timescaledb.compress_segmentby = 'series_id',
+    timescaledb.compress_orderby = 'time',
+    timescaledb.compress_chunk_time_interval = '1 day');
+INSERT INTO test9 (time, series_id, value) SELECT t, s, s%6 FROM generate_series(NOW(), NOW()+INTERVAL'4h', INTERVAL '30s') t CROSS JOIN generate_series(0, 100, 1) s;
+SELECT compress_chunk(c, true) FROM show_chunks('test9') c;
+              compress_chunk               
+-------------------------------------------
+ _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_320_chunk
+ _timescaledb_internal._hyper_17_320_chunk
+(5 rows)
+
+-- Verify index is being is correctly built and giving the same results as sequential scan.
+SET enable_indexscan TO OFF;
+SET enable_seqscan TO ON;
+SET enable_bitmapscan TO OFF;
+EXPLAIN (COSTS OFF) SELECT count(*) FROM test9 WHERE series_id IN (1, 50, 99);
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (DecompressChunk) on _hyper_17_320_chunk
+         ->  Seq Scan on compress_hyper_18_325_chunk
+               Filter: (series_id = ANY ('{1,50,99}'::bigint[]))
+(4 rows)
+
+CREATE TABLE seq_data AS SELECT * FROM test9 WHERE series_id IN (1, 50, 99);
+SET enable_indexscan TO ON;
+SET enable_seqscan TO OFF;
+EXPLAIN (COSTS OFF) SELECT count(*) FROM test9 WHERE series_id IN (1, 50, 99);
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Aggregate
+   ->  Custom Scan (DecompressChunk) on _hyper_17_320_chunk
+         ->  Index Scan using compress_hyper_18_325_chunk__compressed_hypertable_18_series_id on compress_hyper_18_325_chunk
+               Index Cond: (series_id = ANY ('{1,50,99}'::bigint[]))
+(4 rows)
+
+CREATE TABLE index_data AS SELECT * FROM test9 WHERE series_id IN (1, 50, 99);
+-- Make sure there are no distinct rows in both tables.
+SELECT count(*)
+FROM seq_data
+FULL OUTER JOIN index_data ON (seq_data.time = index_data.time AND seq_data.series_id = index_data.series_id)
+WHERE (seq_data.*) IS DISTINCT FROM (index_data.*);
+ count 
+-------
+     0
+(1 row)
+
+RESET enable_indexscan;
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+DROP TABLE test9;

--- a/tsl/test/expected/compression_qualpushdown.out
+++ b/tsl/test/expected/compression_qualpushdown.out
@@ -196,36 +196,37 @@ SELECT compress_chunk(i) from show_chunks('pushdown_relabel') i;
 (1 row)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar';
-                     QUERY PLAN                     
-----------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
-         Filter: ((dev_vc)::text = 'varchar'::text)
+   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+         Index Cond: ((dev_vc)::text = 'varchar'::text)
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_c = 'char';
-                    QUERY PLAN                     
----------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
-         Filter: (dev_c = 'char'::bpchar)
+   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+         Index Cond: (dev_c = 'char'::bpchar)
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar' AND dev_c = 'char';
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
-         Filter: (((dev_vc)::text = 'varchar'::text) AND (dev_c = 'char'::bpchar))
+   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+         Index Cond: (((dev_vc)::text = 'varchar'::text) AND (dev_c = 'char'::bpchar))
 (3 rows)
 
 EXPLAIN (costs off) SELECT * FROM pushdown_relabel WHERE dev_vc = 'varchar'::char(10) AND dev_c = 'char'::varchar;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
  Custom Scan (DecompressChunk) on _hyper_5_6_chunk
-   ->  Seq Scan on compress_hyper_6_7_chunk
-         Filter: (((dev_vc)::bpchar = 'varchar   '::character(10)) AND (dev_c = 'char'::bpchar))
-(3 rows)
+   ->  Index Scan using compress_hyper_6_7_chunk__compressed_hypertable_6_dev_vc_dev_c_ on compress_hyper_6_7_chunk
+         Index Cond: (dev_c = 'char'::bpchar)
+         Filter: ((dev_vc)::bpchar = 'varchar   '::character(10))
+(4 rows)
 
 -- test again with index scans
 SET enable_seqscan TO false;

--- a/tsl/test/expected/transparent_decompression-12.out
+++ b/tsl/test/expected/transparent_decompression-12.out
@@ -6745,37 +6745,25 @@ ORDER BY c.id;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered WHERE device_id = 1 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
-(24 rows)
+               ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
+(12 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
@@ -6791,27 +6779,15 @@ ORDER BY c.id;
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
-(35 rows)
+                           ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d.device_id) AND (device_id_peer = 3))
+(23 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-13.out
+++ b/tsl/test/expected/transparent_decompression-13.out
@@ -7828,37 +7828,25 @@ ORDER BY c.id;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered WHERE device_id = 1 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
-(24 rows)
+               ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
+(12 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
@@ -7874,27 +7862,15 @@ ORDER BY c.id;
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
-(35 rows)
+                           ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+(23 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-14.out
+++ b/tsl/test/expected/transparent_decompression-14.out
@@ -8042,37 +8042,25 @@ ORDER BY c.id;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered WHERE device_id = 1 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
-(24 rows)
+               ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
+(12 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
@@ -8088,27 +8076,15 @@ ORDER BY c.id;
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
-(35 rows)
+                           ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+(23 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression-15.out
+++ b/tsl/test/expected/transparent_decompression-15.out
@@ -8044,37 +8044,25 @@ ORDER BY c.id;
 
 -- should have ordered DecompressChunk path because segmentby columns have equality constraints
 :PREFIX SELECT * FROM metrics_ordered WHERE device_id = 1 AND device_id_peer = 3 ORDER BY time DESC LIMIT 10;
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=0 loops=1)
    ->  Custom Scan (ChunkAppend) on metrics_ordered (actual rows=0 loops=1)
          Order: metrics_ordered."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_31_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_31_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_30_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_30_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
          ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk (actual rows=0 loops=1)
-               ->  Sort (actual rows=0 loops=1)
-                     Sort Key: compress_hyper_12_29_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_12_29_chunk (actual rows=0 loops=1)
-                           Filter: ((device_id = 1) AND (device_id_peer = 3))
-                           Rows Removed by Filter: 5
-(24 rows)
+               ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk (actual rows=0 loops=1)
+                     Index Cond: ((device_id = 1) AND (device_id_peer = 3))
+(12 rows)
 
 :PREFIX SELECT DISTINCT ON (d.device_id) * FROM metrics_ordered d INNER JOIN LATERAL (SELECT * FROM metrics_ordered m WHERE m.device_id=d.device_id AND m.device_id_peer = 3 ORDER BY time DESC LIMIT 1 ) m ON true;
-                                                                           QUERY PLAN                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique (actual rows=0 loops=1)
    ->  Nested Loop (actual rows=0 loops=1)
          ->  Merge Append (actual rows=6840 loops=1)
@@ -8090,27 +8078,15 @@ ORDER BY c.id;
                      Order: m."time" DESC
                      Hypertables excluded during runtime: 0
                      ->  Custom Scan (DecompressChunk) on _hyper_11_28_chunk m_1 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_31_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_31_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_31_chunk compress_hyper_12_31_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_27_chunk m_2 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_30_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
+                           ->  Index Scan using compress_hyper_12_30_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_30_chunk compress_hyper_12_30_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
                      ->  Custom Scan (DecompressChunk) on _hyper_11_26_chunk m_3 (actual rows=0 loops=6840)
-                           ->  Sort (actual rows=0 loops=6840)
-                                 Sort Key: compress_hyper_12_29_chunk_1._ts_meta_sequence_num
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
-                                       Filter: ((device_id = d_1.device_id) AND (device_id_peer = 3))
-                                       Rows Removed by Filter: 5
-(35 rows)
+                           ->  Index Scan using compress_hyper_12_29_chunk__compressed_hypertable_12_device_id_ on compress_hyper_12_29_chunk compress_hyper_12_29_chunk_1 (actual rows=0 loops=6840)
+                                 Index Cond: ((device_id = d_1.device_id) AND (device_id_peer = 3))
+(23 rows)
 
 \ir include/transparent_decompression_systemcolumns.sql
 -- This file and its contents are licensed under the Timescale License.

--- a/tsl/test/expected/transparent_decompression_ordered_index-12.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-12.out
@@ -429,28 +429,40 @@ FROM (
         AND mt.device_id = nd.node
         AND mt.time < nd.stop_time) AS subq
 GROUP BY device_id;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: mt.device_id
-   ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time) AND (mt.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Merge Append (actual rows=1541 loops=1)
-               Sort Key: mt.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
+   ->  Sort (actual rows=48 loops=1)
+         Sort Key: mt.device_id
+         Sort Method: quicksort 
+         ->  Nested Loop (actual rows=48 loops=1)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+               ->  Append (actual rows=48 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 96
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 192
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 1
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+(31 rows)
 
 :PREFIX
 SELECT nd.node,
@@ -510,34 +522,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt."time"
    Sort Method: quicksort 
-   ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt.device_id)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(25 rows)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;
@@ -550,30 +566,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt."time"
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (mt.device_id = nd.node)
-         Join Filter: ((mt."time" > nd.start_time) AND (mt."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_4 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 --enable all joins after the tests
 SET enable_mergejoin = TRUE;
@@ -770,8 +794,8 @@ ORDER BY 1,
     2,
     3,
     4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
    Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
    Sort Method: quicksort 
@@ -783,20 +807,15 @@ ORDER BY 1,
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -922,22 +941,20 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                                          QUERY PLAN                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=0 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=7)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (d.device_id = device_id) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=7)
+                     Index Cond: (device_id = d.device_id)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 5
-         ->  Hash (actual rows=7 loops=1)
-               Buckets: 1024  Batches: 1 
-               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 0
+(11 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -949,8 +966,8 @@ FROM device_tbl d
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 WHERE d.device_id = 8
 ORDER BY m.v0;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -961,9 +978,9 @@ ORDER BY m.v0;
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id = 8)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
 (13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
@@ -986,31 +1003,26 @@ ORDER BY m.v0;
          Join Filter: ((m."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_4 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 7)
          ->  Hash (actual rows=0 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7
-(32 rows)
+(27 rows)
 
 SET timescaledb.enable_chunk_append TO TRUE;
 -- github bug 2917 with UNION ALL that references compressed ht

--- a/tsl/test/expected/transparent_decompression_ordered_index-13.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-13.out
@@ -429,28 +429,40 @@ FROM (
         AND mt.device_id = nd.node
         AND mt.time < nd.stop_time) AS subq
 GROUP BY device_id;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: mt_1.device_id
-   ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time) AND (mt_1.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Merge Append (actual rows=1541 loops=1)
-               Sort Key: mt_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
+   ->  Sort (actual rows=48 loops=1)
+         Sort Key: mt_1.device_id
+         Sort Method: quicksort 
+         ->  Nested Loop (actual rows=48 loops=1)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+               ->  Append (actual rows=48 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 96
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 192
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 1
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+(31 rows)
 
 :PREFIX
 SELECT nd.node,
@@ -510,34 +522,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt_1.device_id)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(25 rows)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;
@@ -550,30 +566,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (mt_1.device_id = nd.node)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 --enable all joins after the tests
 SET enable_mergejoin = TRUE;
@@ -770,8 +794,8 @@ ORDER BY 1,
     2,
     3,
     4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
    Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
    Sort Method: quicksort 
@@ -783,20 +807,15 @@ ORDER BY 1,
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -924,22 +943,20 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                                          QUERY PLAN                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=0 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=7)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (d.device_id = device_id) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=7)
+                     Index Cond: (device_id = d.device_id)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 5
-         ->  Hash (actual rows=7 loops=1)
-               Buckets: 1024  Batches: 1 
-               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 0
+(11 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -951,8 +968,8 @@ FROM device_tbl d
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 WHERE d.device_id = 8
 ORDER BY m.v0;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -963,9 +980,9 @@ ORDER BY m.v0;
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id = 8)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
 (13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
@@ -988,31 +1005,26 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 7)
          ->  Hash (actual rows=0 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7
-(32 rows)
+(27 rows)
 
 SET timescaledb.enable_chunk_append TO TRUE;
 -- github bug 2917 with UNION ALL that references compressed ht

--- a/tsl/test/expected/transparent_decompression_ordered_index-14.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-14.out
@@ -429,28 +429,40 @@ FROM (
         AND mt.device_id = nd.node
         AND mt.time < nd.stop_time) AS subq
 GROUP BY device_id;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: mt_1.device_id
-   ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time) AND (mt_1.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Merge Append (actual rows=1541 loops=1)
-               Sort Key: mt_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
+   ->  Sort (actual rows=48 loops=1)
+         Sort Key: mt_1.device_id
+         Sort Method: quicksort 
+         ->  Nested Loop (actual rows=48 loops=1)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+               ->  Append (actual rows=48 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 96
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 192
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 1
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+(31 rows)
 
 :PREFIX
 SELECT nd.node,
@@ -510,34 +522,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt_1.device_id)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(25 rows)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;
@@ -550,30 +566,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (mt_1.device_id = nd.node)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 --enable all joins after the tests
 SET enable_mergejoin = TRUE;
@@ -770,8 +794,8 @@ ORDER BY 1,
     2,
     3,
     4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
    Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
    Sort Method: quicksort 
@@ -783,20 +807,15 @@ ORDER BY 1,
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -924,22 +943,20 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                                          QUERY PLAN                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=0 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=7)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (d.device_id = device_id) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=7)
+                     Index Cond: (device_id = d.device_id)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 5
-         ->  Hash (actual rows=7 loops=1)
-               Buckets: 1024  Batches: 1 
-               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 0
+(11 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -951,8 +968,8 @@ FROM device_tbl d
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 WHERE d.device_id = 8
 ORDER BY m.v0;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -963,9 +980,9 @@ ORDER BY m.v0;
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id = 8)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
 (13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
@@ -988,31 +1005,26 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 7)
          ->  Hash (actual rows=0 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7
-(32 rows)
+(27 rows)
 
 SET timescaledb.enable_chunk_append TO TRUE;
 -- github bug 2917 with UNION ALL that references compressed ht

--- a/tsl/test/expected/transparent_decompression_ordered_index-15.out
+++ b/tsl/test/expected/transparent_decompression_ordered_index-15.out
@@ -431,28 +431,40 @@ FROM (
         AND mt.device_id = nd.node
         AND mt.time < nd.stop_time) AS subq
 GROUP BY device_id;
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  GroupAggregate (actual rows=1 loops=1)
    Group Key: mt_1.device_id
-   ->  Nested Loop (actual rows=48 loops=1)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time) AND (mt_1.device_id = nd.node))
-         Rows Removed by Join Filter: 1493
-         ->  Merge Append (actual rows=1541 loops=1)
-               Sort Key: mt_1.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Materialize (actual rows=1 loops=1541)
+   ->  Sort (actual rows=48 loops=1)
+         Sort Key: mt_1.device_id
+         Sort Method: quicksort 
+         ->  Nested Loop (actual rows=48 loops=1)
                ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(19 rows)
+               ->  Append (actual rows=48 loops=1)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 96
+                           ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 192
+                           ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                           Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                           Rows Removed by Filter: 1
+                           ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: (device_id = nd.node)
+(31 rows)
 
 :PREFIX
 SELECT nd.node,
@@ -512,34 +524,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Merge Join (actual rows=48 loops=1)
-         Merge Cond: (nd.node = mt_1.device_id)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Sort (actual rows=1 loops=1)
-               Sort Key: nd.node
-               Sort Method: quicksort 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-         ->  Sort (actual rows=1250 loops=1)
-               Sort Key: mt_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=1541 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                           ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                           ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                           ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                           ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-(25 rows)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 SET enable_mergejoin = FALSE;
 SET enable_hashjoin = TRUE;
@@ -552,30 +568,38 @@ WHERE mt.time > nd.start_time
     AND mt.device_id = nd.node
     AND mt.time < nd.stop_time
 ORDER BY time;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                          QUERY PLAN                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=48 loops=1)
    Sort Key: mt_1."time"
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=48 loops=1)
-         Hash Cond: (mt_1.device_id = nd.node)
-         Join Filter: ((mt_1."time" > nd.start_time) AND (mt_1."time" < nd.stop_time))
-         Rows Removed by Join Filter: 289
-         ->  Append (actual rows=1541 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=480 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=960 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=5 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=1 loops=1)
+   ->  Nested Loop (actual rows=48 loops=1)
+         ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
+         ->  Append (actual rows=48 loops=1)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk mt_1 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 96
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk mt_2 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 192
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk mt_3 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = nd.node)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk mt_4 (actual rows=48 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=5 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=5 loops=1)
-         ->  Hash (actual rows=1 loops=1)
-               Buckets: 2048  Batches: 1 
-               ->  Seq Scan on nodetime nd (actual rows=1 loops=1)
-(21 rows)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+               ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk mt_5 (actual rows=0 loops=1)
+                     Filter: (("time" > nd.start_time) AND ("time" < nd.stop_time) AND (nd.node = device_id))
+                     Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = nd.node)
+(29 rows)
 
 --enable all joins after the tests
 SET enable_mergejoin = TRUE;
@@ -772,8 +796,8 @@ ORDER BY 1,
     2,
     3,
     4;
-                                                                                QUERY PLAN                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=10 loops=1)
    Sort Key: metrics_ordered_idx."time", metrics_ordered_idx.device_id, metrics_ordered_idx.device_id_peer, metrics_ordered_idx.v0
    Sort Method: quicksort 
@@ -785,20 +809,15 @@ ORDER BY 1,
                      Sort Key: _hyper_1_4_chunk."time" DESC
                      ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk (actual rows=9 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_9_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
+                           ->  Index Scan Backward using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
                      ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk (actual rows=1 loops=1)
                            Filter: (("time" > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND ("time" < now()))
-                           ->  Sort (actual rows=1 loops=1)
-                                 Sort Key: compress_hyper_2_10_chunk._ts_meta_sequence_num DESC
-                                 Sort Method: quicksort 
-                                 ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                                       Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone) AND (device_id = 4) AND (device_id_peer = 5))
-                                       Rows Removed by Filter: 4
-(24 rows)
+                           ->  Index Scan Backward using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                                 Index Cond: ((device_id = 4) AND (device_id_peer = 5))
+                                 Filter: (_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2002 PST'::timestamp with time zone)
+(19 rows)
 
 :PREFIX
 SELECT m.device_id,
@@ -926,22 +945,20 @@ WHERE m.device_id = d.device_id
     AND m.time > '2019-01-01'
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 ORDER BY m.v0;
-                                                                                          QUERY PLAN                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=0 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
-   ->  Hash Join (actual rows=0 loops=1)
-         Hash Cond: (m.device_id = d.device_id)
-         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
-               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+   ->  Nested Loop (actual rows=0 loops=1)
+         ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
+         ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=7)
+               Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (d.device_id = device_id) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=7)
+                     Index Cond: (device_id = d.device_id)
                      Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 5
-         ->  Hash (actual rows=7 loops=1)
-               Buckets: 1024  Batches: 1 
-               ->  Seq Scan on device_tbl d (actual rows=7 loops=1)
-(13 rows)
+                     Rows Removed by Filter: 0
+(11 rows)
 
 -- no matches in metrics_ordered_idx but one row in device_tbl
 :PREFIX
@@ -953,8 +970,8 @@ FROM device_tbl d
     AND m.time < '2000-01-01 0:00:00+0'::text::timestamptz
 WHERE d.device_id = 8
 ORDER BY m.v0;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort (actual rows=1 loops=1)
    Sort Key: m.v0
    Sort Method: quicksort 
@@ -965,9 +982,9 @@ ORDER BY m.v0;
                Rows Removed by Filter: 6
          ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m (actual rows=0 loops=1)
                Filter: (("time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND ("time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-               ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=0 loops=1)
-                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (device_id = 8) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
-                     Rows Removed by Filter: 5
+               ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=0 loops=1)
+                     Index Cond: (device_id = 8)
+                     Filter: ((_ts_meta_max_1 > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (_ts_meta_min_1 < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
 (13 rows)
 
 -- no matches in device_tbl but 1 row in metrics_ordered_idx
@@ -990,31 +1007,26 @@ ORDER BY m.v0;
          Join Filter: ((m_1."time" > 'Tue Jan 01 00:00:00 2019 PST'::timestamp with time zone) AND (m_1."time" < ('2000-01-01 0:00:00+0'::cstring)::timestamp with time zone))
          ->  Append (actual rows=1 loops=1)
                ->  Custom Scan (DecompressChunk) on _hyper_1_1_chunk m_1 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_6_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_6_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_6_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_2_chunk m_2 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_7_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 5
+                     ->  Index Scan using compress_hyper_2_7_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_7_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_3_chunk m_3 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_8_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_8_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_8_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_4_chunk m_4 (actual rows=0 loops=1)
-                     ->  Seq Scan on compress_hyper_2_9_chunk (actual rows=0 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 1
+                     ->  Index Scan using compress_hyper_2_9_chunk__compressed_hypertable_2_device_id_dev on compress_hyper_2_9_chunk (actual rows=0 loops=1)
+                           Index Cond: (device_id = 7)
                ->  Custom Scan (DecompressChunk) on _hyper_1_5_chunk m_5 (actual rows=1 loops=1)
-                     ->  Seq Scan on compress_hyper_2_10_chunk (actual rows=1 loops=1)
-                           Filter: (device_id = 7)
-                           Rows Removed by Filter: 4
+                     ->  Index Scan using compress_hyper_2_10_chunk__compressed_hypertable_2_device_id_de on compress_hyper_2_10_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 7)
          ->  Hash (actual rows=0 loops=1)
                Buckets: 1024  Batches: 1 
                ->  Seq Scan on device_tbl d (actual rows=0 loops=1)
                      Filter: (device_id = 7)
                      Rows Removed by Filter: 7
-(32 rows)
+(27 rows)
 
 SET timescaledb.enable_chunk_append TO TRUE;
 -- github bug 2917 with UNION ALL that references compressed ht

--- a/tsl/test/isolation/expected/compression_conflicts_iso.out
+++ b/tsl/test/isolation/expected/compression_conflicts_iso.out
@@ -38,7 +38,10 @@ t
 (1 row)
 
 step Cc: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|            0
@@ -96,7 +99,10 @@ t
 (1 row)
 
 step Cc: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|            0
@@ -154,7 +160,10 @@ t
 (1 row)
 
 step Cc: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|            0
@@ -212,7 +221,10 @@ t
 (1 row)
 
 step Cc: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|            0
@@ -276,7 +288,10 @@ t
 (1 row)
 
 step Cc: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|            0
@@ -340,7 +355,10 @@ t
 (1 row)
 
 step Cc: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|            0
@@ -404,7 +422,10 @@ t
 step Cc: COMMIT;
 step I1: <... completed>
 step Ic: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|           10
@@ -471,7 +492,10 @@ t
 step Cc: COMMIT;
 step I1: <... completed>
 step Ic: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|           10
@@ -538,7 +562,10 @@ t
 step Cc: COMMIT;
 step I1: <... completed>
 step Ic: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|           10
@@ -605,7 +632,10 @@ t
 step Cc: COMMIT;
 step Iu1: <... completed>
 step Ic: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|           10
@@ -672,7 +702,10 @@ t
 step Cc: COMMIT;
 step Iu1: <... completed>
 step Ic: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|           10
@@ -739,7 +772,10 @@ t
 step Cc: COMMIT;
 step Iu1: <... completed>
 step Ic: COMMIT;
-step SC1: SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1;
+step SC1: 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+
 count(*)|count(*) only
 --------+-------------
       10|           10

--- a/tsl/test/isolation/expected/compression_merge_race.out
+++ b/tsl/test/isolation/expected/compression_merge_race.out
@@ -103,3 +103,50 @@ count|expected
    24|      24
 (1 row)
 
+
+starting permutation: s1_compress_single_chunk s1_compress_all_chunks_single_transaction s3_select_on_compressed_chunk s3_wait_for_finish s1_compress_finish
+step s1_compress_single_chunk: 
+    select compress_chunk(c, true) from show_chunks('sensor_data') c limit 1;
+
+compress_chunk                            
+------------------------------------------
+_timescaledb_internal._hyper_X_X_chunk
+(1 row)
+
+step s1_compress_all_chunks_single_transaction: 
+    BEGIN;
+    select count(compress_chunk(c, true)) from show_chunks('sensor_data') c;
+
+s1: NOTICE:  chunk "_hyper_X_X_chunk" is already compressed
+count
+-----
+   48
+(1 row)
+
+step s3_select_on_compressed_chunk: 
+    DO $$
+    DECLARE
+      hyper_id int;
+      chunk_id int;
+    BEGIN
+      SELECT h.compressed_hypertable_id, c.compressed_chunk_id 
+      INTO hyper_id, chunk_id
+      FROM _timescaledb_catalog.hypertable h 
+      INNER JOIN _timescaledb_catalog.chunk c  
+      ON h.id = c.hypertable_id 
+      WHERE h.table_name = 'sensor_data' 
+      AND c.compressed_chunk_id IS NOT NULL;
+      EXECUTE format('SELECT * 
+        FROM _timescaledb_internal.compress_hyper_%s_%s_chunk 
+        WHERE sensor_id = 40 
+        AND temperature IS NOT NULL;', 
+        hyper_id, 
+        chunk_id);
+    END;
+    $$;
+
+step s3_wait_for_finish: 
+
+step s1_compress_finish: 
+    COMMIT;
+

--- a/tsl/test/isolation/specs/compression_conflicts_iso.spec
+++ b/tsl/test/isolation/specs/compression_conflicts_iso.spec
@@ -50,7 +50,10 @@ step "SChunkStat" {  SELECT status from _timescaledb_catalog.chunk
 
 session "S"
 step "S1" { SELECT count(*) from ts_device_table; }
-step "SC1" { SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; }
+step "SC1" { 
+    ANALYZE ts_device_table; 
+    SELECT (count_chunktable(ch)).* FROM show_chunks('ts_device_table') AS ch LIMIT 1; 
+}
 step "SH" { SELECT total_chunks, number_compressed_chunks from hypertable_compression_stats('ts_device_table'); }
 step "SA" { SELECT * FROM ts_device_table; }
 step "SU" { SELECT * FROM ts_device_table WHERE value IN (98,99); }

--- a/tsl/test/isolation/specs/compression_merge_race.spec.in
+++ b/tsl/test/isolation/specs/compression_merge_race.spec.in
@@ -54,6 +54,7 @@ setup {
    ALTER TABLE sensor_data SET (
    timescaledb.compress, 
    timescaledb.compress_segmentby = 'sensor_id',
+   timescaledb.compress_orderby = 'time',
    timescaledb.compress_chunk_time_interval = '2 hours');
 }
 
@@ -69,6 +70,20 @@ step "s1_compress_first_half_of_chunks" {
      $$
    ); 
 }
+
+step "s1_compress_all_chunks_single_transaction" {
+    BEGIN;
+    select count(compress_chunk(c, true)) from show_chunks('sensor_data') c;
+}
+
+step "s1_compress_finish" {
+    COMMIT;
+}
+
+step "s1_compress_single_chunk" {
+    select compress_chunk(c, true) from show_chunks('sensor_data') c limit 1;
+}
+
 
 # Compress first two chunks, skip two and compress next two etc.
 step "s1_compress_first_two_by_two" {
@@ -116,9 +131,40 @@ step "s3_count_chunks_post_compression" {
     select count(*), 24 as expected from show_chunks('sensor_data');
 }
 
+step "s3_select_on_compressed_chunk" {
+    DO $$
+    DECLARE
+      hyper_id int;
+      chunk_id int;
+    BEGIN
+      SELECT h.compressed_hypertable_id, c.compressed_chunk_id 
+      INTO hyper_id, chunk_id
+      FROM _timescaledb_catalog.hypertable h 
+      INNER JOIN _timescaledb_catalog.chunk c  
+      ON h.id = c.hypertable_id 
+      WHERE h.table_name = 'sensor_data' 
+      AND c.compressed_chunk_id IS NOT NULL;
+      EXECUTE format('SELECT * 
+        FROM _timescaledb_internal.compress_hyper_%s_%s_chunk 
+        WHERE sensor_id = 40 
+        AND temperature IS NOT NULL;', 
+        hyper_id, 
+        chunk_id);
+    END;
+    $$;
+}
+
+step "s3_wait_for_finish" {
+}
+
+
 
 # Check that we produce 24 chunks out of 48 chunks by merging two 1hour chunks
 # into 2 hour chunks from two different sessions. First session will run until
 # it hits an already compressed chunk.
 permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_half_of_chunks" "s2_compress_second_half_of_chunks" (s1_compress_first_half_of_chunks) "s3_unlock_compression" (s2_compress_second_half_of_chunks, s1_compress_first_half_of_chunks) "s3_count_chunks_post_compression"
 permutation "s3_count_chunks_pre_compression" "s3_lock_compression" "s1_compress_first_two_by_two" "s2_compress_second_two_by_two" (s1_compress_first_two_by_two) "s3_unlock_compression" (s2_compress_second_two_by_two, s1_compress_first_two_by_two) "s3_count_chunks_post_compression"
+
+# Check that we can read existing compressed data during chunk compression when merging.
+# The query uses an index scan to verify we are not blocked on using it during compression.
+permutation "s1_compress_single_chunk" "s1_compress_all_chunks_single_transaction" "s3_select_on_compressed_chunk"  "s3_wait_for_finish" "s1_compress_finish"

--- a/tsl/test/shared/expected/constify_timestamptz_op_interval.out
+++ b/tsl/test/shared/expected/constify_timestamptz_op_interval.out
@@ -136,9 +136,10 @@ WHERE time < '2000-01-01'::timestamptz - '6h'::interval
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk
    Filter: ("time" < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
-   ->  Seq Scan on compress_hyper_X_X_chunk
-         Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval)))
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk
+         Index Cond: (device_id = 1)
+         Filter: (_ts_meta_min_1 < ('Sat Jan 01 00:00:00 2000 PST'::timestamp with time zone - '@ 6 hours'::interval))
+(5 rows)
 
 -- month/year intervals are not constified
 :PREFIX

--- a/tsl/test/shared/expected/constraint_exclusion_prepared.out
+++ b/tsl/test/shared/expected/constraint_exclusion_prepared.out
@@ -2189,24 +2189,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2216,24 +2209,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2243,24 +2229,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2270,24 +2249,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2297,24 +2269,17 @@ QUERY PLAN
          Chunks excluded during startup: 0
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < now())
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < now())
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(23 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(16 rows)
 
 DEALLOCATE prep;
 -- executor startup exclusion with chunks excluded
@@ -2333,18 +2298,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2354,18 +2316,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2375,18 +2334,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2396,18 +2352,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 :PREFIX EXECUTE prep;
 QUERY PLAN
@@ -2417,18 +2370,15 @@ QUERY PLAN
          Chunks excluded during startup: 1
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=100 loops=1)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
                Filter: ("time" < ('2000-01-10'::cstring)::timestamp with time zone)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: ((device_id = 1) AND (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone))
-(17 rows)
+               ->  Index Scan Backward using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+                     Filter: (_ts_meta_min_1 < ('2000-01-10'::cstring)::timestamp with time zone)
+(14 rows)
 
 DEALLOCATE prep;
 -- runtime exclusion with LATERAL and 2 hypertables

--- a/tsl/test/shared/expected/ordered_append-12.out
+++ b/tsl/test/shared/expected/ordered_append-12.out
@@ -2226,21 +2226,12 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(9 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -2259,24 +2250,21 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
-(24 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(21 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -2317,18 +2305,15 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
-(16 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(13 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -2611,18 +2596,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -2685,18 +2667,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX
@@ -3042,22 +3021,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test RECORD in targetlist
 :PREFIX
@@ -3074,22 +3046,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test sort column not in targetlist
 :PREFIX
@@ -3135,51 +3100,24 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(48 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(21 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -3198,42 +3136,39 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 8
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
-(42 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(39 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -3274,27 +3209,24 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 8
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(25 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(22 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -3831,27 +3763,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -3938,27 +3867,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append-13.out
+++ b/tsl/test/shared/expected/ordered_append-13.out
@@ -2229,21 +2229,12 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(9 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -2262,24 +2253,21 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
-(24 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(21 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -2320,18 +2308,15 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
-(16 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(13 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -2614,18 +2599,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -2688,18 +2670,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX
@@ -3045,22 +3024,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test RECORD in targetlist
 :PREFIX
@@ -3077,22 +3049,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test sort column not in targetlist
 :PREFIX
@@ -3138,51 +3103,24 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(48 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(21 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -3201,42 +3139,39 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 8
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
-(42 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(39 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -3277,27 +3212,24 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 8
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(25 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(22 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -3834,27 +3766,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -3941,27 +3870,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append-14.out
+++ b/tsl/test/shared/expected/ordered_append-14.out
@@ -2229,21 +2229,12 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(9 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -2262,24 +2253,21 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
-(24 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(21 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -2320,18 +2308,15 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
-(16 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(13 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -2614,18 +2599,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -2688,18 +2670,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX
@@ -3045,22 +3024,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test RECORD in targetlist
 :PREFIX
@@ -3077,22 +3049,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test sort column not in targetlist
 :PREFIX
@@ -3138,51 +3103,24 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(48 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(21 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -3201,42 +3139,39 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 8
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
-(42 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(39 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -3277,27 +3212,24 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 8
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(25 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(22 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -3834,27 +3766,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -3941,27 +3870,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append-15.out
+++ b/tsl/test/shared/expected/ordered_append-15.out
@@ -2248,21 +2248,12 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=30 loops=1)
-(18 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(9 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -2281,24 +2272,21 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 18
-(24 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(21 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -2339,18 +2327,15 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 18
-(16 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(13 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -2633,18 +2618,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -2707,18 +2689,15 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=10076 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 18
-(18 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(15 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX
@@ -3064,22 +3043,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test RECORD in targetlist
 :PREFIX
@@ -3097,22 +3069,15 @@ QUERY PLAN
          ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
                Order: metrics_space_compressed."time" DESC
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-                     ->  Sort (actual rows=1 loops=1)
-                           Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                           Sort Method: quicksort 
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = 1)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                           Index Cond: (device_id = 1)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     ->  Sort (never executed)
-                           Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                 Filter: (device_id = 1)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                           Index Cond: (device_id = 1)
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-                     ->  Sort (never executed)
-                           Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                           ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                                 Filter: (device_id = 1)
-(20 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                           Index Cond: (device_id = 1)
+(13 rows)
 
 -- test sort column not in targetlist
 :PREFIX
@@ -3158,51 +3123,24 @@ QUERY PLAN
    ->  Merge Append (actual rows=1 loops=1)
          Sort Key: _hyper_X_X_chunk.device_id
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=12 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=18 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk.device_id
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-(48 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+(21 rows)
 
 -- time column must be primary sort order
 :PREFIX
@@ -3221,42 +3159,39 @@ QUERY PLAN
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 8
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
                ->  Sort (actual rows=1 loops=1)
                      Sort Key: compress_hyper_X_X_chunk.device_id, compress_hyper_X_X_chunk._ts_meta_sequence_num DESC
                      Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = ANY ('{1,2}'::integer[]))
-                           Rows Removed by Filter: 12
-(42 rows)
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                           Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(39 rows)
 
 -- test equality constraint on ORDER BY prefix
 -- currently not optimized
@@ -3297,27 +3232,24 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Append (actual rows=27348 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 8
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(25 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(22 rows)
 
 -- queries without ORDER BY shouldnt use ordered append
 :PREFIX
@@ -3854,27 +3786,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with ORDER BY date_trunc
 :PREFIX
@@ -3961,27 +3890,24 @@ QUERY PLAN
          ->  Result (actual rows=27348 loops=1)
                ->  Append (actual rows=27348 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=3598 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=4 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 8
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=4 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5038 loops=1)
-                           ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                                 Filter: (device_id = ANY ('{1,2}'::integer[]))
-                                 Rows Removed by Filter: 12
-(27 rows)
+                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
+                                 Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(24 rows)
 
 -- test query with now() should result in ordered ChunkAppend
 :PREFIX

--- a/tsl/test/shared/expected/ordered_append_join-12.out
+++ b/tsl/test/shared/expected/ordered_append_join-12.out
@@ -2754,22 +2754,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -3610,29 +3603,30 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_8 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o2."time", o2.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=10794 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(47 rows)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Sort (actual rows=100 loops=1)
+                     Sort Key: o2."time", o2.device_id
+                     Sort Method: quicksort 
+                     ->  Append (actual rows=68370 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=10794 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+(48 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-13.out
+++ b/tsl/test/shared/expected/ordered_append_join-13.out
@@ -2754,22 +2754,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -3610,29 +3603,30 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o2_1."time", o2_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(47 rows)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Sort (actual rows=100 loops=1)
+                     Sort Key: o2_1."time", o2_1.device_id
+                     Sort Method: quicksort 
+                     ->  Append (actual rows=68370 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+(48 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-14.out
+++ b/tsl/test/shared/expected/ordered_append_join-14.out
@@ -2754,22 +2754,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -3610,29 +3603,30 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o2_1."time", o2_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(47 rows)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Sort (actual rows=100 loops=1)
+                     Sort Key: o2_1."time", o2_1.device_id
+                     Sort Method: quicksort 
+                     ->  Append (actual rows=68370 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+(48 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/ordered_append_join-15.out
+++ b/tsl/test/shared/expected/ordered_append_join-15.out
@@ -2770,22 +2770,15 @@ QUERY PLAN
    ->  Custom Scan (ChunkAppend) on metrics_space_compressed (actual rows=1 loops=1)
          Order: metrics_space_compressed."time" DESC
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=1 loops=1)
-               ->  Sort (actual rows=1 loops=1)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     Sort Method: quicksort 
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=1 loops=1)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (never executed)
-               ->  Sort (never executed)
-                     Sort Key: compress_hyper_X_X_chunk._ts_meta_sequence_num
-                     ->  Seq Scan on compress_hyper_X_X_chunk (never executed)
-                           Filter: (device_id = 1)
-(19 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (never executed)
+                     Index Cond: (device_id = 1)
+(12 rows)
 
 -- test plan with best index is chosen
 -- this should use time index
@@ -3630,29 +3623,30 @@ QUERY PLAN
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=18 loops=1)
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o1_9 (actual rows=5038 loops=1)
                            ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk (actual rows=6 loops=1)
-         ->  Sort (actual rows=100 loops=1)
-               Sort Key: o2_1."time", o2_1.device_id
-               Sort Method: quicksort 
-               ->  Append (actual rows=68370 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
-                           ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
-(47 rows)
+         ->  Materialize (actual rows=100 loops=1)
+               ->  Sort (actual rows=100 loops=1)
+                     Sort Key: o2_1."time", o2_1.device_id
+                     Sort Method: quicksort 
+                     ->  Append (actual rows=68370 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_1 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_2 (actual rows=10794 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=12 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_3 (actual rows=3598 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=4 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_4 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_5 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_6 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_7 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_8 (actual rows=15114 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=18 loops=1)
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk o2_9 (actual rows=5038 loops=1)
+                                 ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_6_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1 (actual rows=6 loops=1)
+(48 rows)
 
 -- test JOIN on device_id
 -- should not use ordered append for 2nd hypertable

--- a/tsl/test/shared/expected/transparent_decompress_chunk-12.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-12.out
@@ -50,10 +50,9 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 12
-(7 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(6 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
@@ -66,10 +65,9 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
-         Filter: (device_id < 0)
-         Rows Removed by Filter: 20
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Index Cond: (device_id < 0)
+(3 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
@@ -134,6 +132,7 @@ QUERY PLAN
 (4 rows)
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -145,6 +144,7 @@ QUERY PLAN
                      Filter: (device_id IS NOT NULL)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -164,10 +164,9 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
@@ -179,6 +178,7 @@ QUERY PLAN
 (4 rows)
 
 --test var op var
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -202,6 +202,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -213,6 +214,7 @@ QUERY PLAN
 
 -- test function calls
 -- not yet pushed down
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -233,13 +235,10 @@ QUERY PLAN
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 2985
-         ->  Sort (actual rows=5 loops=1)
-               Sort Key: compress_hyper_X_X_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 15
-(10 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+               Rows Removed by Filter: 15
+(7 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -269,6 +268,7 @@ QUERY PLAN
                      Rows Removed by Filter: 15
 (10 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -308,7 +308,9 @@ QUERY PLAN
                      Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (9 rows)
 
+RESET parallel_leader_participation;
 --pushdowns between order by and segment by columns
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -369,6 +371,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -385,6 +388,7 @@ QUERY PLAN
 (10 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -397,7 +401,9 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -430,6 +436,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (6 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -448,27 +455,21 @@ QUERY PLAN
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=5 loops=1)
-         Group Key: _hyper_X_X_chunk.device_id
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(7 rows)
+ GroupAggregate (actual rows=5 loops=1)
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(4 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  WindowAgg (actual rows=5 loops=1)
-         ->  HashAggregate (actual rows=5 loops=1)
-               Group Key: _hyper_X_X_chunk.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+ WindowAgg (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(5 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -674,11 +675,12 @@ QUERY PLAN
                Sort Key: m1."time", m1.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                      ->  Seq Scan on compress_hyper_X_X_chunk
-         ->  Sort
-               Sort Key: m2."time", m2.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(11 rows)
+         ->  Materialize
+               ->  Sort
+                     Sort Key: m2."time", m2.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(12 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -692,22 +694,25 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: (m1."time" = m3."time")
+   ->  Merge Join
+         Merge Cond: (m1."time" = m3."time")
          ->  Merge Join
                Merge Cond: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
                ->  Sort
                      Sort Key: m1."time", m1.device_id
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Seq Scan on compress_hyper_X_X_chunk
-               ->  Sort
-                     Sort Key: m2."time", m2.device_id
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                     Index Cond: (device_id = 3)
-(16 rows)
+               ->  Materialize
+                     ->  Sort
+                           Sort Key: m2."time", m2.device_id
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+         ->  Sort
+               Sort Key: m3."time"
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                           Index Cond: (device_id = 3)
+(19 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -784,11 +789,12 @@ QUERY PLAN
                Sort Key: m1."time", m1.device_id
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                      ->  Seq Scan on compress_hyper_X_X_chunk
-         ->  Sort
-               Sort Key: m2."time", m2.device_id
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                     ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(11 rows)
+         ->  Materialize
+               ->  Sort
+                     Sort Key: m2."time", m2.device_id
+                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(12 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *

--- a/tsl/test/shared/expected/transparent_decompress_chunk-13.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-13.out
@@ -50,10 +50,9 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 12
-(7 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(6 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
@@ -66,10 +65,9 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
-         Filter: (device_id < 0)
-         Rows Removed by Filter: 20
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Index Cond: (device_id < 0)
+(3 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
@@ -134,6 +132,7 @@ QUERY PLAN
 (4 rows)
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -145,6 +144,7 @@ QUERY PLAN
                      Filter: (device_id IS NOT NULL)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -164,10 +164,9 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
@@ -179,6 +178,7 @@ QUERY PLAN
 (4 rows)
 
 --test var op var
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -202,6 +202,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -213,6 +214,7 @@ QUERY PLAN
 
 -- test function calls
 -- not yet pushed down
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -233,13 +235,10 @@ QUERY PLAN
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 2985
-         ->  Sort (actual rows=5 loops=1)
-               Sort Key: compress_hyper_X_X_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 15
-(10 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+               Rows Removed by Filter: 15
+(7 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -269,6 +268,7 @@ QUERY PLAN
                      Rows Removed by Filter: 15
 (10 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -308,7 +308,9 @@ QUERY PLAN
                      Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (9 rows)
 
+RESET parallel_leader_participation;
 --pushdowns between order by and segment by columns
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -369,6 +371,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -385,6 +388,7 @@ QUERY PLAN
 (10 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -397,7 +401,9 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -430,6 +436,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (6 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -448,29 +455,21 @@ QUERY PLAN
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=5 loops=1)
-         Group Key: _hyper_X_X_chunk.device_id
-         Batches: 1 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+ GroupAggregate (actual rows=5 loops=1)
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(4 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  WindowAgg (actual rows=5 loops=1)
-         ->  HashAggregate (actual rows=5 loops=1)
-               Group Key: _hyper_X_X_chunk.device_id
-               Batches: 1 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(9 rows)
+ WindowAgg (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(5 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -694,8 +693,8 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: (m1."time" = m3."time")
+   ->  Merge Join
+         Merge Cond: (m1."time" = m3."time")
          ->  Nested Loop
                Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
                ->  Gather Merge
@@ -706,10 +705,12 @@ QUERY PLAN
                                  ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                     Index Cond: (device_id = 3)
-(16 rows)
+         ->  Sort
+               Sort Key: m3."time"
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                           Index Cond: (device_id = 3)
+(18 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -844,11 +845,12 @@ QUERY PLAN
                      Sort Key: m1."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Seq Scan on compress_hyper_X_X_chunk
-               ->  Sort
-                     Sort Key: m2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(14 rows)
+               ->  Materialize
+                     ->  Sort
+                           Sort Key: m2."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(15 rows)
 
 -- test self-join with sub-query
 :PREFIX_NO_VERBOSE
@@ -874,11 +876,12 @@ QUERY PLAN
                      Sort Key: m1."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Seq Scan on compress_hyper_X_X_chunk
-               ->  Sort
-                     Sort Key: m2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(14 rows)
+               ->  Materialize
+                     ->  Sort
+                           Sort Key: m2."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(15 rows)
 
 RESET parallel_leader_participation;
 :PREFIX

--- a/tsl/test/shared/expected/transparent_decompress_chunk-14.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-14.out
@@ -50,10 +50,9 @@ QUERY PLAN
    Sort Key: t."time", t.device_id
    Sort Method: quicksort 
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-         ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-               Filter: (device_id = ANY ('{1,2}'::integer[]))
-               Rows Removed by Filter: 12
-(7 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+               Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(6 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
@@ -66,10 +65,9 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
-         Filter: (device_id < 0)
-         Rows Removed by Filter: 20
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Index Cond: (device_id < 0)
+(3 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
@@ -134,6 +132,7 @@ QUERY PLAN
 (4 rows)
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -145,6 +144,7 @@ QUERY PLAN
                      Filter: (device_id IS NOT NULL)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -164,10 +164,9 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
@@ -179,6 +178,7 @@ QUERY PLAN
 (4 rows)
 
 --test var op var
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -202,6 +202,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -213,6 +214,7 @@ QUERY PLAN
 
 -- test function calls
 -- not yet pushed down
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -233,13 +235,10 @@ QUERY PLAN
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 2985
-         ->  Sort (actual rows=5 loops=1)
-               Sort Key: compress_hyper_X_X_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 15
-(10 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+               Rows Removed by Filter: 15
+(7 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -269,6 +268,7 @@ QUERY PLAN
                      Rows Removed by Filter: 15
 (10 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -308,7 +308,9 @@ QUERY PLAN
                      Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (9 rows)
 
+RESET parallel_leader_participation;
 --pushdowns between order by and segment by columns
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -369,6 +371,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -385,6 +388,7 @@ QUERY PLAN
 (10 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -397,7 +401,9 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -430,6 +436,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (6 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -448,29 +455,21 @@ QUERY PLAN
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=5 loops=1)
-         Group Key: _hyper_X_X_chunk.device_id
-         Batches: 1 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+ GroupAggregate (actual rows=5 loops=1)
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(4 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  WindowAgg (actual rows=5 loops=1)
-         ->  HashAggregate (actual rows=5 loops=1)
-               Group Key: _hyper_X_X_chunk.device_id
-               Batches: 1 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(9 rows)
+ WindowAgg (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(5 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -694,8 +693,8 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: (m1."time" = m3."time")
+   ->  Merge Join
+         Merge Cond: (m1."time" = m3."time")
          ->  Nested Loop
                Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
                ->  Gather Merge
@@ -706,10 +705,12 @@ QUERY PLAN
                                  ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                     Index Cond: (device_id = 3)
-(16 rows)
+         ->  Sort
+               Sort Key: m3."time"
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                           Index Cond: (device_id = 3)
+(18 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -844,11 +845,12 @@ QUERY PLAN
                      Sort Key: m1."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Seq Scan on compress_hyper_X_X_chunk
-               ->  Sort
-                     Sort Key: m2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(14 rows)
+               ->  Materialize
+                     ->  Sort
+                           Sort Key: m2."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(15 rows)
 
 -- test self-join with sub-query
 :PREFIX_NO_VERBOSE
@@ -874,11 +876,12 @@ QUERY PLAN
                      Sort Key: m1."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Seq Scan on compress_hyper_X_X_chunk
-               ->  Sort
-                     Sort Key: m2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(14 rows)
+               ->  Materialize
+                     ->  Sort
+                           Sort Key: m2."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(15 rows)
 
 RESET parallel_leader_participation;
 :PREFIX

--- a/tsl/test/shared/expected/transparent_decompress_chunk-15.out
+++ b/tsl/test/shared/expected/transparent_decompress_chunk-15.out
@@ -51,10 +51,9 @@ QUERY PLAN
    Sort Method: quicksort 
    ->  Result (actual rows=7196 loops=1)
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk t (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test empty targetlist
 :PREFIX SELECT FROM :TEST_TABLE;
@@ -67,10 +66,9 @@ QUERY PLAN
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < 0;
 QUERY PLAN
  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=0 loops=1)
-   ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=0 loops=1)
-         Filter: (device_id < 0)
-         Rows Removed by Filter: 20
-(4 rows)
+   ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=0 loops=1)
+         Index Cond: (device_id < 0)
+(3 rows)
 
 -- test targetlist not referencing columns
 :PREFIX SELECT 1 FROM :TEST_TABLE;
@@ -136,6 +134,7 @@ QUERY PLAN
 (4 rows)
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -147,6 +146,7 @@ QUERY PLAN
                      Filter: (device_id IS NOT NULL)
 (7 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -166,10 +166,9 @@ QUERY PLAN
          Sort Key: _hyper_X_X_chunk."time", _hyper_X_X_chunk.device_id
          Sort Method: top-N heapsort 
          ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=7196 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=8 loops=1)
-                     Filter: (device_id = ANY ('{1,2}'::integer[]))
-                     Rows Removed by Filter: 12
-(8 rows)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=8 loops=1)
+                     Index Cond: (device_id = ANY ('{1,2}'::integer[]))
+(7 rows)
 
 -- test cast pushdown
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
@@ -181,6 +180,7 @@ QUERY PLAN
 (4 rows)
 
 --test var op var
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -204,6 +204,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (7 rows)
 
+RESET parallel_leader_participation;
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -215,6 +216,7 @@ QUERY PLAN
 
 -- test function calls
 -- not yet pushed down
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -235,13 +237,10 @@ QUERY PLAN
    ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=5 loops=1)
          Filter: ("time" = 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
          Rows Removed by Filter: 2985
-         ->  Sort (actual rows=5 loops=1)
-               Sort Key: compress_hyper_X_X_chunk.device_id
-               Sort Method: quicksort 
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=5 loops=1)
-                     Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
-                     Rows Removed by Filter: 15
-(10 rows)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=5 loops=1)
+               Filter: ((_ts_meta_min_1 <= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone) AND (_ts_meta_max_1 >= 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone))
+               Rows Removed by Filter: 15
+(7 rows)
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -271,6 +270,7 @@ QUERY PLAN
                      Rows Removed by Filter: 15
 (10 rows)
 
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -310,7 +310,9 @@ QUERY PLAN
                      Filter: (_ts_meta_max_1 > 'Fri Dec 31 17:00:00 1999 PST'::timestamp with time zone)
 (9 rows)
 
+RESET parallel_leader_participation;
 --pushdowns between order by and segment by columns
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=0 loops=1)
@@ -371,6 +373,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
@@ -387,6 +390,7 @@ QUERY PLAN
 (10 rows)
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -399,7 +403,9 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (8 rows)
 
+RESET parallel_leader_participation;
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -432,6 +438,7 @@ QUERY PLAN
                ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
 (6 rows)
 
+RESET parallel_leader_participation;
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 QUERY PLAN
  Limit (actual rows=10 loops=1)
@@ -450,29 +457,21 @@ QUERY PLAN
 -- test aggregate with GROUP BY
 :PREFIX SELECT count(*) FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  HashAggregate (actual rows=5 loops=1)
-         Group Key: _hyper_X_X_chunk.device_id
-         Batches: 1 
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-               ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(8 rows)
+ GroupAggregate (actual rows=5 loops=1)
+   Group Key: _hyper_X_X_chunk.device_id
+   ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+         ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(4 rows)
 
 -- test window functions with GROUP BY
 :PREFIX SELECT sum(count(*)) OVER () FROM :TEST_TABLE GROUP BY device_id ORDER BY device_id;
 QUERY PLAN
- Sort (actual rows=5 loops=1)
-   Sort Key: _hyper_X_X_chunk.device_id
-   Sort Method: quicksort 
-   ->  WindowAgg (actual rows=5 loops=1)
-         ->  HashAggregate (actual rows=5 loops=1)
-               Group Key: _hyper_X_X_chunk.device_id
-               Batches: 1 
-               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
-                     ->  Seq Scan on compress_hyper_X_X_chunk (actual rows=20 loops=1)
-(9 rows)
+ WindowAgg (actual rows=5 loops=1)
+   ->  GroupAggregate (actual rows=5 loops=1)
+         Group Key: _hyper_X_X_chunk.device_id
+         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk (actual rows=17990 loops=1)
+               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk (actual rows=20 loops=1)
+(5 rows)
 
 -- test CTE
 :PREFIX WITH q AS (
@@ -696,8 +695,8 @@ FROM :TEST_TABLE m1
     LIMIT 10;
 QUERY PLAN
  Limit
-   ->  Nested Loop
-         Join Filter: (m1."time" = m3."time")
+   ->  Merge Join
+         Merge Cond: (m1."time" = m3."time")
          ->  Nested Loop
                Join Filter: ((m1."time" = m2."time") AND (m1.device_id = m2.device_id))
                ->  Gather Merge
@@ -708,10 +707,12 @@ QUERY PLAN
                                  ->  Parallel Seq Scan on compress_hyper_X_X_chunk
                ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
                      ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-         ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
-               ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
-                     Index Cond: (device_id = 3)
-(16 rows)
+         ->  Sort
+               Sort Key: m3."time"
+               ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m3
+                     ->  Index Scan using compress_hyper_X_X_chunk__compressed_hypertable_4_device_id__t on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_2
+                           Index Cond: (device_id = 3)
+(18 rows)
 
 :PREFIX_NO_VERBOSE
 SELECT *
@@ -846,11 +847,12 @@ QUERY PLAN
                      Sort Key: m1."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Seq Scan on compress_hyper_X_X_chunk
-               ->  Sort
-                     Sort Key: m2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(14 rows)
+               ->  Materialize
+                     ->  Sort
+                           Sort Key: m2."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(15 rows)
 
 -- test self-join with sub-query
 :PREFIX_NO_VERBOSE
@@ -876,11 +878,12 @@ QUERY PLAN
                      Sort Key: m1."time"
                      ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m1
                            ->  Seq Scan on compress_hyper_X_X_chunk
-               ->  Sort
-                     Sort Key: m2."time"
-                     ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
-                           ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
-(14 rows)
+               ->  Materialize
+                     ->  Sort
+                           Sort Key: m2."time"
+                           ->  Custom Scan (DecompressChunk) on _hyper_X_X_chunk m2
+                                 ->  Seq Scan on compress_hyper_X_X_chunk compress_hyper_X_X_chunk_1
+(15 rows)
 
 RESET parallel_leader_participation;
 :PREFIX

--- a/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
+++ b/tsl/test/shared/sql/transparent_decompress_chunk.sql.in
@@ -57,7 +57,9 @@ ORDER BY time, device_id;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 ORDER BY time, device_id LIMIT 10;
 
 -- test IS NULL / IS NOT NULL
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NOT NULL ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id IS NULL ORDER BY time, device_id LIMIT 10;
 
@@ -68,14 +70,17 @@ ORDER BY time, device_id;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = '1'::text::int ORDER BY time, device_id LIMIT 10;
 
 --test var op var
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = v0 ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v1 ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 -- test expressions
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = 1 + 4 / 2 ORDER BY time, device_id LIMIT 10;
 
 -- test function calls
 -- not yet pushed down
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id = length(substring(version(), 1, 3)) ORDER BY time, device_id LIMIT 10;
 
 --
@@ -85,11 +90,14 @@ ORDER BY time, device_id;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time = '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time <= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time >= '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE '2000-01-01 1:00:00+0' < time ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 --pushdowns between order by and segment by columns
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < 1 ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 < device_id ORDER BY time, device_id LIMIT 10;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE device_id < v0 ORDER BY time, device_id LIMIT 10;
@@ -97,20 +105,25 @@ ORDER BY time, device_id;
 
 --pushdown between two order by column (not pushed down)
 :PREFIX SELECT * FROM :TEST_TABLE WHERE v0 = v1 ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 --pushdown of quals on order by and segment by cols anded together
 :PREFIX_VERBOSE SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' AND device_id = 1 ORDER BY time, device_id LIMIT 10;
 
 --pushdown of quals on order by and segment by cols or together (not pushed down)
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time > '2000-01-01 1:00:00+0' OR device_id = 1 ORDER BY time, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 --functions not yet optimized
+SET parallel_leader_participation TO false;
 :PREFIX SELECT * FROM :TEST_TABLE WHERE time < now() ORDER BY time, device_id LIMIT 10;
 
 -- test sort optimization interaction
 :PREFIX SELECT time FROM :TEST_TABLE ORDER BY time DESC LIMIT 10;
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY time DESC, device_id LIMIT 10;
+RESET parallel_leader_participation;
 
 :PREFIX SELECT time, device_id FROM :TEST_TABLE ORDER BY device_id, time DESC LIMIT 10;
 

--- a/tsl/test/sql/compression_errors.sql
+++ b/tsl/test/sql/compression_errors.sql
@@ -353,6 +353,7 @@ EXPLAIN SELECT DISTINCT 1 FROM test;
 
 --compress chunks
 SELECT COMPRESS_CHUNK(X) FROM SHOW_CHUNKS('test') X;
+ANALYZE test;
 
 --below query should pass after chunks are compressed
 SELECT 1 FROM test GROUP BY enum_col;


### PR DESCRIPTION
If there any indexes on the compressed chunk, insert into them while inserting the heap data rather than reindexing the relation at the end. This reduces the amount of locking on the compressed chunk indexes which created issues when merging chunks and should help with the future updates of compressed data.